### PR TITLE
Fix typo in biome config installation instructions

### DIFF
--- a/configs/biome/README.md
+++ b/configs/biome/README.md
@@ -3,7 +3,7 @@
 ## Install
 
 ```sh
-bun i -d @canonical/biome-config
+bun add -d @canonical/biome-config
 ```
 
 ## Consume


### PR DESCRIPTION
## Done

Fixes a typo in the biome config installation instructions (incorrect bun install syntax)

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] All packages define the required scripts in `package.json`: `build`, `check`, and `check:fix`.
