### PR TITLE
Add negative button, move variants to global intents

### DIFF
--- a/packages/ds-react-core/src/ui/Button/Button.stories.ts
+++ b/packages/ds-react-core/src/ui/Button/Button.stories.ts
@@ -41,11 +41,21 @@ export const Positive: Story = {
 };
 
 /**
+ * A negative button can be used to indicate a negative action that is destructive or permanent.
+ */
+export const Negative: Story = {
+  args: {
+    label: "Delete",
+    appearance: "negative",
+  },
+};
+
+/**
  * Custom button props can be passed to the button component.
  */
 export const Custom: Story = {
   args: {
-    label: "Custom",
+    label: "Customize",
     className: "custom-class",
     style: {
       "--button-background-color": "lightblue",

--- a/packages/ds-react-core/src/ui/Button/Button.stories.tsx
+++ b/packages/ds-react-core/src/ui/Button/Button.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 
 import Component from "./Button.js";
+import Button from "./Button.js";
 
 const meta = {
   title: "Button",
@@ -64,5 +65,35 @@ export const Custom: Story = {
       "--button-background-color-hover": "lightskyblue",
       "--button-background-color-active": "skyblue",
     } as React.CSSProperties,
+  },
+};
+
+/**
+ * There is a flaw in the idea of having "intents" implemented globally like states.
+ * Intent variables are inherited with CSS, so will be applied to all child elements. For example, if there is a "positive" notification, the child buttons without "intent" (default) will also be positive.
+ *
+ * This is probably OK for states, because it's likely that all child elements will be in the same state. But it's not OK for intents, because we can't assume all child elements share the same intent.
+ */
+export const BrokenIntents: Story = {
+  decorators: [
+    (Story) => (
+      <div
+        className="positive"
+        style={{
+          border: "2px solid var(--intent-color)",
+          padding: "1rem",
+        }}
+      >
+        <p>I'm a wrapper with <code>positive</code> intent class name.</p>
+        <Button label="This should be a default button" />
+        <Button
+          label="This should be a negative button"
+          appearance="negative"
+        />
+      </div>
+    ),
+  ],
+  args: {
+    label: "Broken",
   },
 };

--- a/packages/ds-react-core/src/ui/Button/Button.stories.tsx
+++ b/packages/ds-react-core/src/ui/Button/Button.stories.tsx
@@ -59,22 +59,20 @@ export const Custom: Story = {
     label: "Customize",
     className: "custom-class",
     style: {
-      "--button-background-color": "lightblue",
-      "--button-text-color": "midnightblue",
-      "--button-border-color": "midnightblue",
-      "--button-background-color-hover": "lightskyblue",
-      "--button-background-color-active": "skyblue",
+      "--button-color-background": "lightblue",
+      "--button-color-text": "midnightblue",
+      "--button-color-border": "midnightblue",
+      "--button-color-background-hover": "lightskyblue",
+      "--button-color-background-active": "skyblue",
     } as React.CSSProperties,
   },
 };
 
 /**
- * There is a flaw in the idea of having "intents" implemented globally like states.
- * Intent variables are inherited with CSS, so will be applied to all child elements. For example, if there is a "positive" notification, the child buttons without "intent" (default) will also be positive.
- *
- * This is probably OK for states, because it's likely that all child elements will be in the same state. But it's not OK for intents, because we can't assume all child elements share the same intent.
+ * Intent variables are inherited with CSS, so will be applied to all child elements. For example, if there is a "positive" notification, the child buttons without "intent" will also be positive.
+ * For the child element to have a different intent, the intent class name should be explicitly added.
  */
-export const BrokenIntents: Story = {
+export const IntentsInheritance: Story = {
   decorators: [
     (Story) => (
       <div
@@ -84,12 +82,12 @@ export const BrokenIntents: Story = {
           padding: "1rem",
         }}
       >
-        <p>I'm a wrapper with <code>positive</code> intent class name.</p>
-        <Button label="This should be a default button" />
-        <Button
-          label="This should be a negative button"
-          appearance="negative"
-        />
+        <p>
+          I'm a wrapper with <code>positive</code> intent class name.
+        </p>
+        <Button label="This is a neutral button" appearance="neutral" />
+        <Button label="This is a negative button" appearance="negative" />
+        <Button label="This button inherits the intent from parent" />
       </div>
     ),
   ],

--- a/packages/ds-react-core/src/ui/Button/Button.tsx
+++ b/packages/ds-react-core/src/ui/Button/Button.tsx
@@ -18,7 +18,7 @@ export interface ButtonProps {
   /** Additional CSS classes */
   className?: string;
   /** The visual style of the button */
-  appearance?: "default" | "base" | "positive" | "negative" | "link";
+  appearance?: "neutral" | "base" | "positive" | "negative" | "link";
   /** Button contents */
   label: string;
   /** Optional click handler */
@@ -33,19 +33,14 @@ export type ButtonPropsType = ButtonProps &
 const Button = ({
   id,
   className,
-  appearance = "default",
+  appearance,
   label,
   ...props
 }: ButtonPropsType): React.ReactElement => {
   return (
     <button
       id={id}
-      className={[
-        "ds",
-        "button",
-        appearance !== "default" && appearance,
-        className,
-      ]
+      className={["ds", "button", appearance, className]
         .filter(Boolean)
         .join(" ")}
       {...props}

--- a/packages/ds-react-core/src/ui/Button/styles.css
+++ b/packages/ds-react-core/src/ui/Button/styles.css
@@ -1,13 +1,13 @@
 /* component styles */
 
 /* component variables
-    --button-background-color: background color of the button
-    --button-background-color-hover: background color of the button on hover
-    --button-background-color-active: background color of the button on active
-    --button-text-color: text color of the button
-    --button-border-color: border color of the button
-    --button-border-color-hover: border color of the button on hover
-    --button-border-color-active: border color of the button on active
+    --button-color-background: background color of the button
+    --button-color-background-hover: background color of the button on hover
+    --button-color-background-active: background color of the button on active
+    --button-color-text: text color of the button
+    --button-color-border: border color of the button
+    --button-color-border-hover: border color of the button on hover
+    --button-color-border-active: border color of the button on active
 
     --button-margin-left: left margin of the button
     --button-margin-bottom: bottom margin of the button
@@ -22,36 +22,18 @@
   display: inline-block;
   cursor: pointer;
 
-  color: var(
-    --button-text-color,
-    var(--intent-color-text, var(--color-text-default))
-  );
-  background-color: var(
-    --button-background-color,
-    var(--intent-color, var(--color-background-default))
-  );
-  border-color: var(
-    --button-border-color,
-    var(--intent-color, var(--color-border-high-contrast))
-  );
+  color: var(--intent-color-text, var(--button-color-text));
+  background-color: var(--intent-color, var(--button-color-background));
+  border-color: var(--intent-color-border, var(--button-color-border));
   border-style: solid;
-  border-width: var(--button-border-width, var(--spacing-border-width));
-  font-size: var(--button-font-size, var(--font-size-default));
-  font-weight: var(--button-font-weight, var(--font-weight-default));
-  line-height: var(--button-line-height, var(--line-height-default));
-  margin-block-end: var(
-    --button-margin-bottom,
-    var(--spacing-input-margin-bottom)
-  );
-  margin-inline-end: var(--button-margin-left, var(--spacing-horizontal-large));
-  padding-block: var(
-    --button-padding-vertical,
-    var(--spacing-input-padding-vertical)
-  );
-  padding-inline: var(
-    --button-padding-horizontal,
-    var(--spacing-horizontal-large)
-  );
+  border-width: var(--button-border-width);
+  font-size: var(--button-font-size);
+  font-weight: var(--button-font-weight);
+  line-height: var(--button-line-height);
+  margin-block-end: var(--button-margin-bottom);
+  margin-inline-end: var(--button-margin-left);
+  padding-block: var(--button-padding-vertical);
+  padding-inline: var(--button-padding-horizontal);
 
   text-align: left;
   text-decoration: none;
@@ -59,23 +41,23 @@
   /* component states */
   &:hover {
     background-color: var(
-      --button-background-color-hover,
-      var(--intent-color-hover, var(--color-background-hover))
+      --intent-color-hover,
+      var(--button-color-background-hover)
     );
     border-color: var(
-      --button-border-color-hover,
-      var(--intent-color-hover, var(--color-border-high-contrast))
+      --intent-color-border-hover,
+      var(--button-color-border-hover)
     );
   }
 
   &:active {
     background-color: var(
-      --button-background-color-active,
-      var(--intent-color-active, var(--color-background-active))
+      --intent-color-active,
+      var(--button-color-background-active)
     );
     border-color: var(
-      --button-border-color-active,
-      var(--intent-color-active, var(--color-border-high-contrast))
+      --intent-color-border-active,
+      var(--button-color-border-active)
     );
   }
 }

--- a/packages/ds-react-core/src/ui/Button/styles.css
+++ b/packages/ds-react-core/src/ui/Button/styles.css
@@ -22,12 +22,18 @@
   display: inline-block;
   cursor: pointer;
 
-  color: var(--button-text-color, var(--color-text-default));
+  color: var(
+    --button-text-color,
+    var(--intent-color-text, var(--color-text-default))
+  );
   background-color: var(
     --button-background-color,
-    var(--color-background-default)
+    var(--intent-color, var(--color-background-default))
   );
-  border-color: var(--button-border-color, var(--color-border-high-contrast));
+  border-color: var(
+    --button-border-color,
+    var(--intent-color, var(--color-border-high-contrast))
+  );
   border-style: solid;
   border-width: var(--button-border-width, var(--spacing-border-width));
   font-size: var(--button-font-size, var(--font-size-default));
@@ -54,39 +60,22 @@
   &:hover {
     background-color: var(
       --button-background-color-hover,
-      var(--color-background-hover)
+      var(--intent-color-hover, var(--color-background-hover))
     );
     border-color: var(
       --button-border-color-hover,
-      var(--color-border-high-contrast)
+      var(--intent-color-hover, var(--color-border-high-contrast))
     );
   }
 
   &:active {
     background-color: var(
       --button-background-color-active,
-      var(--color-background-active)
+      var(--intent-color-active, var(--color-background-active))
     );
     border-color: var(
       --button-border-color-active,
-      var(--color-border-high-contrast)
+      var(--intent-color-active, var(--color-border-high-contrast))
     );
-  }
-
-  /* TODO: move to separate state/intent classes file */
-  &.positive {
-    background-color: var(--color-background-positive-default);
-    color: var(--color-text-button-positive);
-    border-color: var(--color-background-positive-default);
-
-    &:hover {
-      background-color: var(--color-background-positive-hover);
-      border-color: var(--color-background-positive-hover);
-    }
-
-    &:active {
-      background-color: var(--color-background-positive-active);
-      border-color: var(--color-background-positive-active);
-    }
   }
 }

--- a/packages/styles/src/intents.css
+++ b/packages/styles/src/intents.css
@@ -3,6 +3,9 @@
   --intent-color-hover: var(--color-background-positive-hover);
   --intent-color-active: var(--color-background-positive-active);
   --intent-color-text: var(--color-background-positive-text);
+  --intent-color-border: var(--intent-color);
+  --intent-color-border-hover: var(--intent-color-hover);
+  --intent-color-border-active: var(--intent-color-active);
 }
 
 .negative {
@@ -10,4 +13,17 @@
   --intent-color-hover: var(--color-background-negative-hover);
   --intent-color-active: var(--color-background-negative-active);
   --intent-color-text: var(--color-background-negative-text);
+  --intent-color-border: var(--intent-color);
+  --intent-color-border-hover: var(--intent-color-hover);
+  --intent-color-border-active: var(--intent-color-active);
+}
+
+.neutral {
+  --intent-color: var(--color-background-default);
+  --intent-color-hover: var(--color-background-hover);
+  --intent-color-active: var(--color-background-active);
+  --intent-color-text: var(--color-text-default);
+  --intent-color-border: var(--color-border-high-contrast);
+  --intent-color-border-hover: var(--intent-color-border);
+  --intent-color-border-active: var(--intent-color-border);
 }

--- a/packages/styles/src/intents.css
+++ b/packages/styles/src/intents.css
@@ -1,7 +1,13 @@
 .positive {
-  --color: green;
+  --intent-color: var(--color-background-positive-default);
+  --intent-color-hover: var(--color-background-positive-hover);
+  --intent-color-active: var(--color-background-positive-active);
+  --intent-color-text: var(--color-background-positive-text);
 }
 
 .negative {
-  --color: red;
+  --intent-color: var(--color-background-negative-default);
+  --intent-color-hover: var(--color-background-negative-hover);
+  --intent-color-active: var(--color-background-negative-active);
+  --intent-color-text: var(--color-background-negative-text);
 }

--- a/packages/styles/src/tokens.css
+++ b/packages/styles/src/tokens.css
@@ -2,8 +2,11 @@
 :root {
   /* color tokens */
   /* based on: https://docs.google.com/spreadsheets/d/1AY6BLFU-Cnj48ggHUnNVlWRxwWZ6Z-66s7jxJC1HLSU/edit?gid=1738212977#gid=1738212977 */
-  --color-background-default: #fff;
-  --color-text-default: #000;
+  --color-palette-white: #fff;
+  --color-palette-black: #000;
+
+  --color-background-default: var(--color-palette-white);
+  --color-text-default: var(--color-palette-black);
   --color-background-hover: rgba(242, 242, 242, 1);
   --color-background-active: rgba(235, 235, 235, 1);
   --color-border-high-contrast: rgba(0, 0, 0, 0.56);
@@ -11,7 +14,12 @@
   --color-background-positive-default: rgba(14, 132, 32, 1);
   --color-background-positive-hover: rgba(12, 109, 26, 1);
   --color-background-positive-active: rgba(10, 95, 23, 1);
-  --color-text-button-positive: rgba(255, 255, 255, 1);
+  --color-background-positive-text: var(--color-palette-white); /* text on positive background */
+
+  --color-background-negative-default: rgba(199, 22, 43, 1);
+  --color-background-negative-hover: rgba(176, 19, 38, 1);
+  --color-background-negative-active: rgba(162, 18, 35, 1);
+  --color-background-negative-text: var(--color-palette-white); /* text on positive background */
 
   /* spacing tokens */
   --spacing-horizontal-small: 0.5rem;

--- a/packages/styles/src/tokens.css
+++ b/packages/styles/src/tokens.css
@@ -1,3 +1,5 @@
+/* TODO: this should potentially be part of the theme definition, as it implements design decisions specific to the theme */
+
 /* base tokens */
 :root {
   /* color tokens */
@@ -36,4 +38,24 @@
   --font-size-default: 1rem;
   --font-weight-default: 400;
   --line-height-default: 1.5rem;
+}
+
+/* component semantic tokens */
+:root {
+  --button-color-background: var(--color-background-default);
+  --button-color-background-hover: var(--color-background-hover);
+  --button-color-background-active: var(--color-background-active);
+  --button-color-text: var(--color-text-default);
+  --button-color-border: var(--color-border-high-contrast);
+  --button-color-border-hover: var(--button-color-border);
+  --button-color-border-active: var(--button-color-border);
+
+  --button-margin-left: var(--spacing-horizontal-large);
+  --button-margin-bottom: var(--spacing-input-margin-bottom);
+  --button-padding-vertical: var(--spacing-input-padding-vertical);
+  --button-padding-horizontal: var(--spacing-horizontal-large);
+  --button-border-width: var(--spacing-border-width);
+  --button-font-size: var(--font-size-default);
+  --button-font-weight: var(--font-weight-default);
+  --button-line-height: var(--line-height-default);
 }


### PR DESCRIPTION
## Done

Moves positive variant to "intents".

## QA

- Go to ds-react-core package directory
- `bun run storybook`
- navigate to button page: `http://0.0.0.0:6006/?path=/docs/example-button--docs`

## QA

- [Add QA steps]

### PR readiness check

- [ ] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] All packages define the required scripts in `package.json`: `build`, `check`, and `check:fix`.

## Screenshots

<img width="1086" alt="image" src="https://github.com/user-attachments/assets/52cff559-5e76-4d42-9e33-da8b14c7d3e2">



