### PR TITLE
Added basic heading styles

### DIFF
--- a/packages/ds-react-core/src/ui/Typography.stories.tsx
+++ b/packages/ds-react-core/src/ui/Typography.stories.tsx
@@ -1,0 +1,80 @@
+// FIXME
+// This doesn't really fit in the ds-react-core package,
+// but it's a simple way to show examples in existing Storybook.
+// TODO:
+// - do we need a separate Storybook/examples for styles package?
+// - should he have a separate Storybook package, that would group all stories from different sources?
+
+const meta = {
+  title: "Styles / Typography",
+};
+
+export default meta;
+
+export const Headings = {
+  decorators: [
+    () => (
+      <>
+        <h1>This is a sample of the &lt;h1&gt; heading</h1>
+        <h2>This is a sample of the &lt;h2&gt; heading</h2>
+        <h3>This is a sample of the &lt;h3&gt; heading</h3>
+        <h4>This is a sample of the &lt;h4&gt; heading</h4>
+        <h5>This is a sample of the &lt;h5&gt; heading</h5>
+        <h6>This is a sample of the &lt;h6&gt; heading</h6>
+      </>
+    ),
+  ],
+};
+
+export const HeadingsClasses = {
+  decorators: [
+    () => (
+      <>
+        <p className="heading-1">Learn DevOps best practices</p>
+        <p className="heading-2">Companies involved in OpenStack</p>
+        <p className="heading-3">Latest news from our blog</p>
+        <p className="heading-4">Further reading</p>
+        <p className="heading-5">Kubernetes</p>
+        <p className="heading-6">
+          Ubuntu is an open source software operating system
+        </p>
+      </>
+    ),
+  ],
+};
+
+export const HeadingsMixedClasses = {
+  decorators: [
+    () => (
+      <>
+        <h6 className="heading-1">
+          Ubuntu is an open source software operating system
+        </h6>
+        <h5 className="heading-2">Kubernetes</h5>
+        <h4 className="heading-3">Further reading</h4>
+        <h3 className="heading-4">Latest news from our blog</h3>
+        <h2 className="heading-5">Companies involved in OpenStack</h2>
+        <h1 className="heading-6">Learn DevOps best practices</h1>
+      </>
+    ),
+  ],
+};
+
+export const Subheadings = {
+  decorators: [
+    () => (
+      <>
+        <h1>Title</h1>
+        <p className="heading-3">Sub-heading</p>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipiscing elit praesent justo.
+        </p>
+        <h2>Title</h2>
+        <p className="heading-4">Sub-heading</p>
+        <p>
+          Lorem ipsum dolor sit amet consectetur adipiscing elit praesent justo.
+        </p>
+      </>
+    ),
+  ],
+};

--- a/packages/styles/src/font-faces.css
+++ b/packages/styles/src/font-faces.css
@@ -1,3 +1,9 @@
+/*
+TODO
+- add optional character subset version of the font - how to do it conditinoally?
+- reconsider the font-family name - "Ubuntu variable" was a workaround for backwards compatibility with previous "Ubuntu" web font, do we still need this? what would happen if we change it to "Ubuntu"?
+*/
+
 /* Ubuntu font declarations, as per Vanilla */
 @font-face {
   font-family: "Ubuntu variable";

--- a/packages/styles/src/index.css
+++ b/packages/styles/src/index.css
@@ -1,17 +1,10 @@
+/* Reset */
 @import url("normalize.css");
+
+/* Values and settings */
 @import url("./tokens.css");
 @import url("./font-faces.css");
-@import url("./intents.css");
 
-html {
-  color: #000;
-  font-family: "Ubuntu variable", "Ubuntu", -apple-system, "Segoe UI", "Roboto",
-    "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  font-weight: 400;
-  line-height: 1.5rem;
-  text-wrap: pretty;
-  font-size: 1rem;
-}
+/* Foundations styling */
+@import url("./typography.css");
+@import url("./intents.css");

--- a/packages/styles/src/typography.css
+++ b/packages/styles/src/typography.css
@@ -1,0 +1,182 @@
+/*
+TODO
+- conditional (?) font size increase on large screens
+- different heading sizes/spacing on different screen sizes
+- how to make very opinionated styles (heading sizes in pairs, margin collapsing between them, etc) configurable/themable?
+*/
+
+:root {
+  --font-family-sans: "Ubuntu variable", "Ubuntu", -apple-system, "Segoe UI",
+    "Roboto", "Oxygen", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
+  --font-family-mono: "Ubuntu Mono variable", "Ubuntu Mono", Consolas, Monaco,
+    Courier, monospace;
+  --text-max-width: 40em;
+
+  --font-size-default: 1rem;
+  --font-size-default-scaled: 1.125rem;
+
+  --font-size-h1: 2.5rem;
+  --font-size-h2: var(--font-size-h1);
+  --font-size-h3: 1.5rem;
+  --font-size-h4: var(--font-size-h3);
+
+  --font-weight-bold: 550;
+  --font-weight-regular: 400;
+  --font-weight-thin: 300;
+  --font-weight-display-heading: 100;
+  --font-weight-h2: 180; /* custom font weight for h2 */
+  --font-weight-h4: 275; /* custom font weight for h4 */
+
+  --sp-unit: 0.5rem;
+  --spv-x-small: calc(0.5 * var(--sp-unit));
+  --spv-small: var(--sp-unit);
+  --spv-medium: calc(1.5 * var(--sp-unit));
+  --spv-large: calc(2 * var(--sp-unit));
+  --spv-x-large: calc(3 * var(--sp-unit));
+  --spv-strip-shallow: calc(3 * var(--sp-unit));
+  --spv-strip-regular: calc(8 * var(--sp-unit));
+  --spv-strip-deep: calc(16 * var(--sp-unit));
+
+  --sp-after-display: var(--spv-x-large);
+  --sp-after-h1: var(--spv-x-large);
+  --sp-after-h2: var(--sp-after-h1);
+  --sp-after-h3: var(--spv-x-large);
+  --sp-after-h4: var(--sp-after-h3);
+  --sp-after-p: var(--spv-x-large);
+  --sp-after-p-small-caps: var(--spv-large);
+  --sp-after-p-dense: var(--spv-large);
+  --sp-after-default-text: var(--sp-unit);
+  --sp-after-small: var(--spv-large);
+  --sp-after-small-dense: var(--spv-large);
+  --sp-after-x-small: var(--spv-large);
+
+  --line-height-default: calc(3 * var(--sp-unit));
+  --line-height-h1: calc(6 * var(--sp-unit));
+  --line-height-h2: var(--line-height-h1);
+  --line-height-h3: calc(4 * var(--sp-unit));
+  --line-height-h4: var(--line-height-h3);
+
+  --nudge-p: 0.375rem;
+  --nudge-h1: 0.55rem;
+  --nudge-h2: var(--nudge-h1);
+  --nudge-h3: 0.45rem;
+  --nudge-h4: var(--nudge-h3);
+  --nudge-h5: var(--nudge-p);
+  --nudge-h6: var(--nudge-p);
+}
+
+html {
+  color: #000;
+  font-family: var(--font-family-sans);
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  font-weight: var(--font-weight-regular);
+  font-size: var(--font-size-default);
+  line-height: var(--line-height-default);
+  text-wrap: pretty;
+}
+
+/* FIXME: we would need to add many more selectors here, everything that is a heading (in components) */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+.heading-1,
+.heading-2,
+.heading-3,
+.heading-4,
+.heading-5,
+.heading-6 {
+  font-style: normal;
+  margin-top: 0;
+  max-width: var(--text-max-width);
+}
+
+h1,
+.heading-1 {
+  font-size: var(--font-size-h1);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-h1);
+  padding-top: var(--nudge-h1);
+  margin-bottom: calc(var(--sp-after-h1) - var(--nudge-h1));
+}
+
+h2,
+.heading-2 {
+  font-size: var(--font-size-h2);
+  font-weight: var(--font-weight-h2);
+  line-height: var(--line-height-h2);
+  padding-top: var(--nudge-h2);
+  margin-bottom: calc(var(--sp-after-h2) - var(--nudge-h2));
+}
+
+h3,
+.heading-3 {
+  font-size: var(--font-size-h3);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-h3);
+  padding-top: var(--nudge-h3);
+  margin-bottom: calc(var(--sp-after-h3) - var(--nudge-h3));
+}
+
+h4,
+.heading-4 {
+  font-size: var(--font-size-h4);
+  font-weight: var(--font-weight-h4);
+  line-height: var(--line-height-h4);
+  padding-top: var(--nudge-h4);
+  margin-bottom: calc(var(--sp-after-h4) - var(--nudge-h4));
+}
+
+h5,
+.heading-5 {
+  font-size: var(--font-size-default);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-default);
+  padding-top: var(--nudge-h5);
+  margin-bottom: calc(var(--sp-after-p) - var(--nudge-h5));
+}
+
+h6,
+.heading-6 {
+  font-size: var(--font-size-default);
+  font-style: italic;
+  font-weight: var(--font-weight-regular);
+  line-height: var(--line-height-default);
+  padding-top: var(--nudge-h6);
+  margin-bottom: calc(var(--sp-after-p) - var(--nudge-h6));
+}
+
+/*
+  Canonical specific:
+  consecutive headings of the same size should collapse margin between them
+*/
+h1,
+h2,
+.heading-1,
+.heading-2 {
+  & + & {
+    margin-top: calc(-1 * var(--sp-after-h1));
+  }
+}
+
+h3,
+h4,
+.heading-3,
+.heading-4 {
+  & + & {
+    margin-top: calc(-1 * var(--sp-after-h3));
+  }
+}
+
+h5,
+h6,
+.heading-5,
+.heading-6 {
+  & + & {
+    margin-top: calc(-1 * var(--sp-after-p));
+  }
+}


### PR DESCRIPTION
## Done

Adds basic typography styles for headings.

Note:
- styles are added to the styles package
- storybook docs are added to ds-react-core package (so that they can be presented with the rest of the docs)

## Open questions (can be addressed later):

1. How to address typography changes on different screen sizes? Current Vanilla uses media queries to change heading sizes between mobile/larger screens, and the basic unit size is increased on very large screens.
2. Base styles have their own package, but storybook is in `ds-react-core` package. Should docs/stories for other packages be kept in `ds-react-core`? Should we have separate storybooks in each package? Should we one storybook external to any packages, that would collect all examples from different packages (is that possible)?
3. In Vanilla we have different font-files for Ubuntu font based on character subsets. Do we still need this? How should we implement it in configurable way?

## QA

- Run the storybook in `ds-react-core`
- Check typography examples

## Screenshots

<img width="974" alt="image" src="https://github.com/user-attachments/assets/9069ee8f-6ff2-4266-9c1a-b5aed7ec21ca">
