### PR TITLE
Update generator global install package manager documentation

### DIFF
--- a/apps/generator-canonical-ds/README.md
+++ b/apps/generator-canonical-ds/README.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-1. Install [Yeoman](https://yeoman.io/): `bun add -g yo`
+1. Install [Yeoman](https://yeoman.io/) and this generator: `npm i -g yo @canonical/generator-canonical-ds`
 2. Run the generator: `yo @canonical/canonical-ds`
 3. Select a subgenerator from the list and follow its instructions
 


### PR DESCRIPTION
## Done

Mitigates #53 by suggesting users to use `npm` instead of `bun ` to globally install the code generator.

## QA
Perform these steps **outside of the monorepo** to verify that the generator package from the monorepo workspace is not visible to your node environment.

1. `npm i -g yo @canonical/generator-canonical-ds`
2. `yo --generators` - Verify the generator is listed in the options
3. `yo @canonical/generator-canonical-ds` - Verify the generator runs successfully.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] All packages define the required scripts in `package.json`: `build`, `check`, and `check:fix`.
