### PR TITLE
fix: Lerna only versions packages that have changed

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -59,6 +59,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+          # Lerna needs *all* the git history to determine which packages have changed
+          fetch-depth: 0
 
       - name: Setup environment
         uses: ./.github/actions/setup-env
@@ -79,7 +81,9 @@ jobs:
         run: |
           git add .
           git commit -m "chore: version bump to ${{ steps.lerna_version.outputs.VERSION }}"
-          git tag "v${{ steps.lerna_version.outputs.VERSION }}"
+          # Create an annotated tag (`-m`) so that lerna can use it to determine which packages have changed
+          # See https://github.com/lerna/lerna/issues/1357#issuecomment-438162152
+          git tag "v${{ steps.lerna_version.outputs.VERSION }}" -m "v${{ steps.lerna_version.outputs.VERSION }}"
           git push && git push --tags
 
   publish:
@@ -90,8 +94,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          # Checkout the tag that was just created
           ref: v${{ needs.version.outputs.VERSION }}
+          # Lerna needs *all* the git history to determine which packages have changed
+          fetch-depth: 0
 
         # "prepare" hook on `bun install` runs `bun run build`
       - name: Setup Environment


### PR DESCRIPTION
## Done

Fixes `lerna version` and `lerna publish` versioning and publishing packages that were not changed since the last release.

### What was the problem?

The above commands use `git describe --abbrev=0` under the hood to find the latest **annotated** git tag made before the current commit.

The problem was twofold:
#### Our git tags were un-annotated
`lerna version` creates annotated tags by default. However, since we need to run `bun run check:fix` to apply formatting before creating a tag, we didn't get this behavior for free. We manually create tags, but are not currently using `-m` to annotate the tag. This causes lerna to be unable to find a previous tag and assume that all packages have changed.

See [source](https://github.com/lerna/lerna/issues/1357#issuecomment-438162152) for more details.

#### Our CI was checking out shallow commit histories
After I fixed the problem with commits being un-annotated, I noticed that lerna was behaving as expected locally, but not on my fork's CI on GitHub Actions. I found [this issue](https://github.com/lerna/lerna/issues/2542) which mentions that using the checkout action with the wrong `fetch-depth` can cause the latest tag to not be pulled by the CI runner, again causing Lerna to be unable to find the latest tag, and version all packages.

Fixes #44 

## QA

1. Review [test workflow ](https://github.com/jmuzina/ds25/actions/runs/12186232271/job/33994294823) on my fork. This workflow was run on a commit that only changed the root `README.md` (no changes to packages were made. See that it does not version any packages, as no changes were found.

```
lerna info current version 0.3.1-experimental.0
lerna info Looking for changed packages since v0.3.1-experimental.0
lerna success No changed packages to version
nothing to commit, working tree clean
```
This fails the workflow (as expected, since nothing has changed), and does not push any tags or publish any packages.

2. Review [second test workflow](https://github.com/jmuzina/ds25/actions/runs/12186255673/job/33994382639). This workflow was run on a commit that changed `packages/ds-react-core/README.md`. It causes the react core package and the boilerplate (which depends on the react core package) to be updated.

```
lerna info current version 0.3.1-experimental.0
lerna info Looking for changed packages since v0.3.1-experimental.0

Changes:
 - @canonical/boilerplate-react-vite: 0.3.1-experimental.0 => 0.3.2-experimental.0 (private)
 - @canonical/ds-react-core: 0.3.1-experimental.0 => 0.3.2-experimental.0

lerna success version finished
```
This [versions both packages](https://github.com/jmuzina/ds25/commit/6790a65112e8b15f84f3b245079f57c8ea5cd9cf) (and updates the boilerplate's version of the react core). 

Then, the [publishing workflow](https://github.com/jmuzina/ds25/actions/runs/12186255673/job/33994410851) runs `lerna publish from-package`, which publishes packages which have updated their `package.json`. It publishes just the react core package (since the boilerplate is marked private). 

```
Found 1 package to publish:
lerna info auto-confirmed 
 - @canonical/ds-react-core => 0.3.2-experimental.0

lerna info publish Publishing packages to npm...
```

Disregard the publishing workflow failing: my fork does not have a `NODE_AUTH_TOKEN` set to avoid publishing needlessly.

In preparation for merging this, I have already re-created the latest tag `v0.3.1-experimental.0` with a tag annotation, so the next publishing workflow will not needlessly publish `v0.3.2-experimental.0` for packages that are not changed.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] All packages define the required scripts in `package.json`: `build`, `check`, and `check:fix`.
