### PR TITLE
Incremental CI/CD workflows

### DIFF
--- a/.github/actions/lerna-version/action.yml
+++ b/.github/actions/lerna-version/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
 outputs:
   VERSION:
-    description: "The new latest version number across all packages"
+    description: "The new latest tag across all packages"
     value: ${{ steps.lerna_version.outputs.VERSION }}
 runs:
   using: composite
@@ -20,8 +20,3 @@ runs:
       shell: bash
       id: lerna_version
       run: ${{ github.action_path }}/version.sh "${{ inputs.update_type }}" "${{ inputs.prerelease_identifier }}"
-
-      # Lerna may introuce slight formatting changes to the package.json files
-    - name: Format files
-      shell: bash
-      run: bun run check:fix

--- a/.github/actions/lerna-version/version.sh
+++ b/.github/actions/lerna-version/version.sh
@@ -15,6 +15,11 @@ fi
 # Do not commit or tag as we need to re-format the package files before committing
 bun run lerna version $VERSION_ARGS --no-git-tag-version --no-push --yes
 
+# `lerna version` may cause `package.json` files to fail linting rules.
+# See https://github.com/lerna/lerna/issues/4117
+# We don't run `check:fix` here; passing in previous tag for package filtering makes the API for this action too messy.
+echo "Package versions updated. Run the 'check:fix' command to apply formatting fixes."
+
 # Extract the updated version from lerna.json
 VERSION=$(jq -r '.version' lerna.json)
 echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -1,18 +1,28 @@
 name: Setup environment
 description: Installs build tools and dependencies
 inputs:
-  bun-version: 
+  bun-version:
     default: latest
     description: Version of Bun to use
+  ignore_scripts:
+    default: "false"
+    description: Skip any lifecycle scripts defined to run on `bun install`
 runs:
   using: composite
   steps:
     - name: Setup Bun
       uses: oven-sh/setup-bun@v2
-      with: 
+      with:
         bun-version: ${{ inputs.bun-version }}
 
-      # "prepare" hook on `bun install` runs `bun run build`
     - name: Install dependencies
       shell: bash
-      run: bun install --frozen-lockfile
+      run: |
+        install_args="--frozen-lockfile"
+        
+        if [ "${{ inputs.ignore_scripts }}" == "true" ]; then
+          echo "Ignoring post-install scripts. If you need built packages, make sure you run 'bun run build'."
+          install_args="$install_args --ignore-scripts"
+        fi
+        
+        bun install $install_args

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,16 +3,26 @@ on:
   pull_request:
     branches:
       - main
+env:
+  PR_TARGET_REF: "refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
+        with:
+          # Lerna needs *all* the git history to determine which packages have changed
+          fetch-depth: 0
 
-        # "prepare" hook on `bun install` runs `bun run build`
       - name: Setup environment
         uses: ./.github/actions/setup-env
+        with:
+          # Ignore lifecycle scripts to avoid building packages that haven't changed
+          ignore_scripts: true
 
-      - name: Run tests
-        run: bun run test
+      - name: Build changed packages
+        run: bun run lerna run build --since ${{ env.PR_TARGET_REF }}
+
+      - name: Code quality checks
+        run: bun run lerna run check --since ${{ env.PR_TARGET_REF }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,5 +18,5 @@ jobs:
       - name: Setup environment
         uses: ./.github/actions/setup-env
 
-      - name: Run tests
-        run: bun run test
+      - name: Code quality checks
+        run: bun run check

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       update_type:
-        description: "Verion update type"
+        description: "Version update type"
         required: true
         # Change to minor once project is stable
         default: "prepatch"
@@ -21,16 +21,19 @@ on:
         required: false
         type: string
 env:
-  MAIN_BRANCH: "refs/heads/main"
+  MAIN_BRANCH_REF: "refs/heads/main"
 
 jobs:
-  build:
-    name: Build & test
+  version:
+    name: Bump package versions
     runs-on: ubuntu-latest
+    outputs:
+      PREV_VERSION: ${{ steps.prev_version.outputs.PREV_VERSION }}
+      VERSION: ${{ steps.lerna_version.outputs.VERSION }}
     steps:
       - name: Validate input
         run: |
-          if [[ "${{ github.ref }}" != "${{ env.MAIN_BRANCH }}" ]]; then
+          if [[ "${{ github.ref }}" != "${{ env.MAIN_BRANCH_REF }}" ]]; then
             echo "This action can only be run on the main branch"
             exit 1
           fi
@@ -38,39 +41,35 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
-
-        # "prepare" hook on `bun install` runs `bun run build`
-      - name: Setup environment
-        uses: ./.github/actions/setup-env
-
-        # TODO add Nx and only test the packages that have changed since last tag
-      - name: Run tests
-        run: bun run test
-
-  version:
-    name: Bump package versions
-    runs-on: ubuntu-latest
-    needs: build
-    outputs:
-      VERSION: ${{ steps.lerna_version.outputs.VERSION }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           # Lerna needs *all* the git history to determine which packages have changed
           fetch-depth: 0
 
+      - name: Get previous version
+        id: prev_version
+        run: echo "PREV_VERSION=$(git describe --abbrev=0)" >> $GITHUB_OUTPUT
+
       - name: Setup environment
         uses: ./.github/actions/setup-env
+        with:
+          # Ignore lifecycle scripts to avoid building packages that haven't changed
+          ignore_scripts: true
 
-      - name: Bump package versions
+        # Building changed packages manually since we ignored lifecycle scripts on `bun install`
+      - name: Build changed packages
+        run: bun run lerna run build --since ${{ steps.prev_version.outputs.PREV_VERSION }}
+
+      - name: Update changed package versions
         id: lerna_version
         uses: ./.github/actions/lerna-version
         with:
           update_type: ${{ github.event.inputs.update_type }}
           prerelease_identifier: ${{ github.event.inputs.prerelease_identifier }}
+
+      # `lerna version` may introduce slight formatting changes to the package.json files.
+      # So, we run formatting fixes before running code quality checks and committing the changes.
+      - name: Format files and run code quality checks
+        run: bun run lerna run check:fix --since ${{ steps.prev_version.outputs.PREV_VERSION }}
 
       - name: Setup Git CLI
         uses: ./.github/actions/setup-git
@@ -91,18 +90,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: version
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          # Checkout the tag that was just created
-          ref: v${{ needs.version.outputs.VERSION }}
-          # Lerna needs *all* the git history to determine which packages have changed
-          fetch-depth: 0
-
-        # "prepare" hook on `bun install` runs `bun run build`
-      - name: Setup Environment
-        uses: ./.github/actions/setup-env
-
       - name: Setup Node, authenticate with NPM registry
         uses: actions/setup-node@v4.1.0
         with:
@@ -111,5 +98,24 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
 
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Checkout the tag that was just created
+          ref: v${{ needs.version.outputs.VERSION }}
+          # Lerna needs *all* the git history to determine which packages have changed
+          fetch-depth: 0
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+        with:
+          ignore_scripts: true
+
+      - name: Build changed packages
+        run: bun run lerna run build --since ${{ needs.version.outputs.PREV_VERSION }}
+
+        # `lerna publish` does not have a `--since` flag; by default it will run the pre-publish lifecycle
+        #   for all packages, even if they weren't changed.
+        #   `--ignore-scripts` solves this and is safe - the updated packages are built in the env setup step.
       - name: Publish packages
-        run: lerna publish --yes --no-private from-package
+        run: lerna publish from-package --no-private --ignore-scripts --yes

--- a/nx.json
+++ b/nx.json
@@ -2,18 +2,15 @@
   "cli": {
     "packageManager": "bun"
   },
-  "cacheableOperations": ["build", "test", "check", "check:fix"],
   "targetDefaults": {
     "build": {
       "dependsOn": ["^build"],
       "cache": true
     },
     "check": {
-      "dependsOn": ["^check"],
       "cache": true
     },
     "check:fix": {
-      "dependsOn": ["^check:fix"],
       "cache": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "build": "lerna run build",
     "prepare": "bun run build",
     "lerna": "lerna",
-    "test": "bun run check",
     "check": "lerna run check",
     "check:fix": "lerna run check:fix"
   },


### PR DESCRIPTION
## Done

- The CI/CD pipeline now only builds & tests packages that need to be built and tested.
  - In the CI pipeline, the PR's merge commit is tested against its target branch. Packages that are changed (directly or indirectly) by a PR, as well as packages that have been changed on the target branch since the PR branch was created, will be built and tested. Other packages will be skipped.
  - In the CD pipeline, the packages and dependents that have changed since the previous tag will be be built and tested. 
- Drive-by: Consolidated the "Tag" workflow into two jobs - the "build" job was used to build and test, but the "version" job needs to build and test anyway in order to perform package versioning. This behavior has been consolidated in order to use less time and resources.

Fixes #60 

## QA

1. Open [test PR](https://github.com/jmuzina/ds25/pull/17) that makes a [change to the react tsconfig](https://github.com/jmuzina/ds25/pull/17/commits/43c9443859e066fca3f77e279633b27fcb1ff14e). 
2. Inspect the [PR CI workflow](https://github.com/jmuzina/ds25/actions/runs/12206931095/job/34057422032) and see that only the `ds-react-core` and `boilerplate-react-vite` packages are built (they both depend on the React tsconfig, and the React tsconfig has no build script). 

<img width="667" alt="Screenshot 2024-12-06 at 17 28 13" src="https://github.com/user-attachments/assets/d91b0b9b-a4ca-4849-97c1-2eb51e8cfb69">

3. See that the react tsconfig, boilerplate, and react core packges are all `check`'d

<img width="667" alt="Screenshot 2024-12-06 at 17 28 42" src="https://github.com/user-attachments/assets/d3e9465f-b1a8-4f7b-a815-8e5bae22fc7c">

4. Inspect the [CD workflow](https://github.com/jmuzina/ds25/actions/runs/12206947695/job/34057471269) and see that the same packages modified by QA step 2 are built.

<img width="566" alt="Screenshot 2024-12-06 at 17 30 31" src="https://github.com/user-attachments/assets/abac992f-a94b-4dfd-bbd4-ce4e88c94b15">

5. Verify that only the packages that are being versioned have format fixing applied to them
<img width="566" alt="Screenshot 2024-12-06 at 17 31 22" src="https://github.com/user-attachments/assets/e8180842-0215-4132-8543-060ce058a946">

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] All packages define the required scripts in `package.json`: `build`, `check`, and `check:fix`.
