### PR TITLE
chore: Generator component types.ts file imports React as a type

### DIFF
--- a/apps/generator-canonical-ds/src/component/templates/types.ts.ejs
+++ b/apps/generator-canonical-ds/src/component/templates/types.ts.ejs
@@ -1,5 +1,5 @@
 /* <%= generatorPackageName %> <%= generatorPackageVersion %> */
-import React from 'react'
+import type React from 'react'
 
 export interface <%= componentName %>Props {
   /* A unique identifier for the <%= componentName %> */


### PR DESCRIPTION
## Done

Changes the React component generator's `React` import to use `import type` instead of `import`.

Fixes #69 

## QA

- Checkout PR
- `bun i`
- `yo @canonical/canonical-ds`
- Generate a new React component
- See that Biome does not suggest to change `import React...` to `import type React` and no other type errors are seen

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check` and `check:fix`.
  - [x] Packages with a build step: `build`.
