### PR TITLE
chore: Sync GitHub issues with Jira

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,36 @@
+settings:
+  # Jira project key to create the issue in
+  jira_project_key: "WD"
+
+  # Dictionary mapping GitHub issue status to Jira issue status
+  status_mapping:
+    opened: Untriaged
+    closed: done
+
+  # (Optional) Jira project components that should be attached to the created issue
+  # Component names are case-sensitive
+  components:
+    - Design System Tribe
+
+    # (Optional) GitHub labels. Only issues with one of those labels will be synchronized.
+    # If not specified, all issues will be synchronized
+    # labels:
+    # - bug
+    # - custom
+
+  # (Optional) (Default: false) Add a new comment in GitHub with a link to Jira created issue
+  add_gh_comment: true
+
+  # (Optional) (Default: true) Synchronize issue description from GitHub to Jira
+  sync_description: true
+
+  # (Optional) (Default: true) Synchronize comments from GitHub to Jira
+  sync_comments: true
+
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  epic_key: "WD-17839"
+
+  # (Optional) Dictionary mapping GitHub issue labels to Jira issue types.
+  # If label on the issue is not in specified list, this issue will be created as a Bug
+  label_mapping:
+    enhancement: Story


### PR DESCRIPTION
## Done

Adds the Jira-GitHub sync configuration from Vanilla Framework. 

New issue activity will sync issues to Jira, under the [Incoming Design System Requests epic](https://warthogs.atlassian.net/browse/WD-17839). This is distinct from the [Incoming Vanilla Requests epic](https://warthogs.atlassian.net/browse/WD-15821) that is used by Vanilla's integration.

Fixes #64 

## QA

- As far as I am aware, there is no way to QA this - issues only start syncing once this is merged. However, you can compare this to the [Vanilla configuration](https://github.com/canonical/vanilla-framework/blob/main/.github/.jira_sync_config.yaml) and ensure that this matches in all but `epic_key`. 

### PR readiness check

- [ ] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check` and `check:fix`.
  - [ ] Packages with a build step: `build`.
