### PR TITLE
fix: generator: use default value (cwd) for component generator path

### DIFF
--- a/packages/generator-ds/src/component/index.ts
+++ b/packages/generator-ds/src/component/index.ts
@@ -34,8 +34,8 @@ export default class ComponentGenerator extends Generator<ComponentGeneratorOpti
 
     this.argument("componentPath", {
       type: String,
-      description: "The path to the component's root directory",
-      required: true,
+      description:
+        "The path to the component's root directory. Defaults to your current working directory.",
       default: this.env.cwd,
     });
 


### PR DESCRIPTION
## Done

Adjusts the configuration of the React component generator so that the current working directory is used as a default if no component path is provided.

Fixes #83 

## QA

- Checkout this PR
- `bun i`
- `yo @canonical/ds:component`: generate a component in the current working directory
- `yo @canonical/ds:component path/to/new/component`: generate a component in a subdirectory relative to the current working directory
- `yo @canonical/ds:component --help`: See that the componentPath help text is updated to mention its default value.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check` and `check:fix`.
  - [ ] Packages with a build step: `build`.

## Screenshots
![Screenshot 2024-12-16 at 15 34 04](https://github.com/user-attachments/assets/e2044be6-d142-46e6-9cad-cf7b6e3b1c17)
![Screenshot 2024-12-16 at 15 35 36](https://github.com/user-attachments/assets/1d55a5d2-f918-4270-9435-ce58845b2d66)

