### PR TITLE
fix(generator): Generator resolves utils dependency at runtime

### DIFF
--- a/packages/generator-ds/CHANGELOG.md
+++ b/packages/generator-ds/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.7.1-experimental.0
+- [chore]: Updated the `package.json` to define a `module` script instead of `main` script, since this is an ESM package.

--- a/packages/generator-ds/package.json
+++ b/packages/generator-ds/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/canonical/ds25#readme",
   "files": ["generators"],
   "type": "module",
-  "main": "generators/index.js",
+  "module": "generators/index.js",
   "scripts": {
     "build": "bun run build:tsc && bun run build:copyfiles",
     "build:tsc": "tsc",

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.7.1-experimental.0
+- [chore]: Added explicit `exports` to `package.json` for better compatibility with `@canonical/generator-ds` at runtime. This prevents errors where Yeoman cannot resolve the import of the utils package.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -10,6 +10,13 @@
     "email": "webteam@canonical.com",
     "name": "Canonical Webteam"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "types": "./dist/types/index.d.ts",
+      "default": "./dist/esm/index.js"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/canonical/ds25"


### PR DESCRIPTION
## Done

Fixes an issue with the code generator where an import of `@canonical/utils` during the Yeoman generator's runtime would cause the generator to fail. The utils package was resolvable at build time, but could not be resolved at runtime. 

Before:
```
➜  ds25 git:(fix-generator-utils-import) ✗ yo @canonical/ds foo                                                     
✖️ An error occured while running @canonical/ds:app#prompting
Error @canonical/ds foo 

Cannot find package '/Users/jmuzina/source/work/canonical/repos/ds25/node_modules/@canonical/utils/package.json' imported from /Users/jmuzina/source/work/canonical/repos/ds25/packages/generator-ds/generators/component/index.js
TypeError [ERR_INVALID_ARG_TYPE]: The "code" argument must be of type number. Received type string ('ERR_MODULE_NOT_FOUND')
    at process.set [as exitCode] (node:internal/bootstrap/node:123:9)
    at process.exit (node:internal/process/per_thread:187:24)
    at onError (/usr/local/lib/node_modules/yo/lib/cli.js:117:11)
    at /usr/local/lib/node_modules/yo/lib/cli.js:168:54
    at async init (/usr/local/lib/node_modules/yo/lib/cli.js:168:5)
    at async pre (/usr/local/lib/node_modules/yo/lib/cli.js:83:3)
    at async /usr/local/lib/node_modules/yo/lib/cli.js:193:3
```
After:
```
➜  ds25 git:(fix-generator-utils-import) yo @canonical/ds it_should_work_now                                      
Welcome to the component generator!
This generator should be run from the root directory of all your application's components (ex: src/components).
This generator supports CLI input only. Use yo @canonical/ds:component --help for more information.
   create Itshouldworknow/Itshouldworknow.tsx
   create Itshouldworknow/index.ts
   create Itshouldworknow/types.ts
   create Itshouldworknow/Itshouldworknow.test.tsx
```

## QA

- Checkout this PR
- Clean install: `bun run special:clean && rm -rf packages/generator-ds/generators && bun i`
- Navigate to react lib: `cd packages/react/ds-core/src/ui`
- Run generator: `yo @canonical/ds NewComponent`

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.
