### PR TITLE
fix(react-core): Export chip component

### DIFF
--- a/packages/react/ds-core/CHANGELOG.md
+++ b/packages/react/ds-core/CHANGELOG.md
@@ -1,0 +1,2 @@
+## 0.7.1-experimental.0
+- [fix]: The `ui/index.ts` file now exports all components from the `ui` directory. Previously, the Chip component was not exported.

--- a/packages/react/ds-core/src/ui/index.ts
+++ b/packages/react/ds-core/src/ui/index.ts
@@ -1,1 +1,2 @@
-export { Button, type ButtonProps } from "./Button/index.js";
+export * from "./Button/index.js";
+export * from "./Chip/index.js";


### PR DESCRIPTION
## Done

Exports the Chip component from the `react-core` package.

## QA

- `bun i`
- Edit `apps/react/boilerplate-vite/src/LazyComponent.tsx` to import the `Chip` component and/or its associated types, see that the import is resolved.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.

## Screenshots
<img width="532" alt="Screenshot 2025-01-17 at 14 39 05" src="https://github.com/user-attachments/assets/150905d3-5d81-48be-b6e2-a202631095c8" />
