### PR TITLE
feat: adding an EditableBlock component

### DIFF
--- a/packages/react/ds-app-launchpad/src/ui/index.ts
+++ b/packages/react/ds-app-launchpad/src/ui/index.ts
@@ -1,1 +1,2 @@
 export { Button, type ButtonProps } from "./Button/index.js";
+export { EditableBlock, type EditableBlockProps } from "./EditableBlock/index.js"

--- a/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/EditableBlock.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/EditableBlock.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+
+import Component from "./EditableBlock.js";
+
+const meta = {
+  title: "EditableBlock",
+  component: Component,
+  tags: ["autodocs"],
+  // if using enum for appearance, you can use the following to generate controls
+  // argTypes: {
+  //   appearance: {
+  //      control: 'select',
+  //      mapping: ButtonAppearance,
+  //      options: Object.keys(ButtonAppearance),
+  //   }
+  // },
+  args: { },
+} satisfies Meta<typeof Component>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Default
+ */
+
+interface SampleChildProps {
+  isEditing?: boolean;
+}
+
+const SampleChild: React.FC<SampleChildProps> = ({ isEditing }) => {
+  return (
+    <div>
+      {isEditing ? 'In editing mode.' : 'View mode.'}
+    </div>
+  );
+};
+
+export const Default: Story = {
+  args: {
+    title: "Sample Title",
+    children: <SampleChild />,
+  },
+};

--- a/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/EditableBlock.test.tsx
+++ b/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/EditableBlock.test.tsx
@@ -1,0 +1,17 @@
+/* @canonical/generator-ds 0.8.0-experimental.0 */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import Component from "./EditableBlock.js";
+
+describe("EditableBlock component", () => {
+  it("renders", () => {
+    render(<Component>EditableBlock</Component>);
+    expect(screen.getByText('EditableBlock')).toBeInTheDocument();
+  });
+
+  it("applies className", () => {
+    render(<Component className={"test-class"}>EditableBlock</Component>);
+    expect(screen.getByText("EditableBlock")).toHaveClass("test-class");
+  });
+});

--- a/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/EditableBlock.tsx
+++ b/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/EditableBlock.tsx
@@ -1,0 +1,62 @@
+/* @canonical/generator-ds 0.8.0-experimental.0 */
+import React, { createContext, useContext, useState, cloneElement, ReactElement } from 'react';
+import type { EditableBlockProps, EditingContextType } from './types.js';
+import "./styles.css";
+
+/**
+ * description of the EditableBlock component
+ * @returns {React.ReactElement} - Rendered EditableBlock
+ */
+
+const EditingContext = createContext<EditingContextType | undefined>(undefined);
+
+export const useEditing = (): EditingContextType => {
+  const context = useContext(EditingContext);
+  if (!context) {
+    throw new Error("useEditing shouldn't be used directly.");
+  }
+  return context;
+};
+
+const EditableBlock = ({
+  id,
+  children,
+  className,
+  style,
+  title,
+}: EditableBlockProps): React.ReactElement => {
+  const [isEditing, setIsEditing] = useState<boolean>(false);
+
+  const toggleEditing = () => {
+    setIsEditing((editing) => !editing);
+  };
+
+  const childrenWithProps = React.Children.map(children, (child) => {
+    if (React.isValidElement(child)) {
+      return cloneElement(child as ReactElement<any>, { isEditing });
+    }
+    return child;
+  });
+
+  return (
+    <EditingContext.Provider value={{ isEditing, toggleEditing }}>
+      <div className="editable-block-component">
+        <div className="editable-block-component__header">
+          <div className="editable-block-component__title">
+            {title}
+          </div>
+          <div className="editable-block-component__icon" onClick={toggleEditing}>
+            <span role="img" aria-label="icon">🖉</span>
+          </div>
+        </div>
+        <div className="editable-block-component__content">
+          <div className="editable-block-component__children">
+            {childrenWithProps}
+          </div>
+        </div>
+      </div>
+    </EditingContext.Provider>
+  )
+};
+
+export default EditableBlock;

--- a/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/index.ts
+++ b/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/index.ts
@@ -1,0 +1,5 @@
+/* @canonical/generator-ds 0.8.0-experimental.0 */
+export { default as EditableBlock } from "./EditableBlock.js";
+export type {
+  default as EditableBlockProps,
+} from "./types.js";

--- a/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/styles.css
+++ b/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/styles.css
@@ -1,0 +1,23 @@
+.editable-block-component__header {
+  display: flex;
+  justify-content: space-between;
+}
+
+.editable-block-component__icon {
+    cursor: pointer;
+    flex: 1;
+    display: flex;
+    justify-content: flex-end;
+}
+
+.editable-block-component__title {
+    flex: 1;
+    text-align: left;
+}
+
+.editable-block-component__children {
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/types.ts
+++ b/packages/react/ds-app-launchpad/src/ui/shared/EditableBlock/types.ts
@@ -1,0 +1,21 @@
+/* @canonical/generator-ds 0.8.0-experimental.0 */
+import type React from 'react'
+
+export interface EditableBlockProps {
+  /* A unique identifier for the EditableBlock */
+  id?: string;
+  /* Additional CSS classes */
+  className?: string;
+  /* Child elements */
+  children: React.ReactNode;
+  /* Inline styles */
+  style?: React.CSSProperties;
+  title: string;
+}
+
+export interface EditingContextType {
+  isEditing: boolean;
+  toggleEditing: () => void;
+}
+
+export default EditableBlockProps


### PR DESCRIPTION
## Done

This PR proposes the addition of the common pattern observed in the figma, of a component that can trigger an "editable" state and provide it to its children.

## QA

- [Add QA steps]

### PR readiness check

- [ ] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with a build step: `build`.

## Screenshots

[if relevant, include a screenshot or screen capture]
