### PR TITLE
fix(storybook-baseline-grid): Fix storybook baseline grid addon not starting

### DIFF
--- a/packages/storybook-addon-baseline-grid/.storybook/local-preset.js
+++ b/packages/storybook-addon-baseline-grid/.storybook/local-preset.js
@@ -2,14 +2,14 @@
  * to load the built addon in this test Storybook
  */
 function previewAnnotations(entry = []) {
-    return [...entry, require.resolve("../dist/preview.js")];
-  }
+  return [...entry, require.resolve("../dist/esm/preview.js")];
+}
 
-  function managerEntries(entry = []) {
-    return [...entry, require.resolve("../dist/manager.js")];
-  }
+function managerEntries(entry = []) {
+  return [...entry, require.resolve("../dist/esm/manager.js")];
+}
 
-  module.exports = {
-    managerEntries,
-    previewAnnotations,
-  };
+module.exports = {
+  managerEntries,
+  previewAnnotations,
+};


### PR DESCRIPTION
Running `bun run storybook` in the storybook baseline grid addon currently throws an error:
```
Error: Cannot find module '../dist/manager.js'
Require stack:
- ./.storybook/local-preset.js
- /Users/jmuzina/source/work/canonical/repos/ds25/node_modules/@storybook/core/dist/common/index.cjs
- /Users/jmuzina/source/work/canonical/repos/ds25/node_modules/storybook/dist/proxy.cjs
- /Users/jmuzina/source/work/canonical/repos/ds25/node_modules/storybook/bin/index.cjs
```

Upon inspection of `local-preset.js`, it seems we have some misconfigured dist paths that needed to be fixed. This PR fixes these dist paths to use `dist/esm/<>` instead of `dist/<>`.

## Done

[List of work items including drive-bys]

Fixes [list issues/bugs if needed]

## QA

- Clone this PR
- `bun run special:clean && cd packages/storybook-addon-baseline-grid && bun run storybook`
- See that the storybook runs without crashing
- Run any storybook in the project that relies on the baseline grid addon (e.g, ds-core). Make sure the baseline grids still appear there.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with a build step: `build`.
