### PR TITLE
fix(generator): Root generator clarity improvements

### DIFF
--- a/packages/generator-ds/src/app/index.ts
+++ b/packages/generator-ds/src/app/index.ts
@@ -9,29 +9,16 @@ export default class BaseGenerator extends Generator {
     },
   ];
 
-  // In prompting mode, prompt the user to select a subgenerator and run that generator
-  async prompting() {
-    const answers = await this.prompt([
-      {
-        type: "list",
-        name: "subgenerator",
-        message: "Please select a subgenerator",
-        choices: this.subgenerators.map((subgen) => ({
-          name: `${subgen.name} (${subgen.description})`,
-          value: subgen.name,
-        })),
-        when: () => this.subgenerators.length > 1,
-        default: this.subgenerators[0].name,
-      },
-    ]);
-    return this.composeWith(
-      `${globalContext.generatorScriptIdentifer}:${answers.subgenerator || this.subgenerators[0].name}`,
-      // Pass CLI args to the subgenerator
-      {
-        generatorArgs: this.args,
-        generatorOptions: this.options,
-      },
-    );
+  /**
+   * The root generator serves as a menuing system for the subgenerators.
+   * Its only purpose is to list subgenerators and prompt the user to select one.
+   * If the user runs the generator without any arguments, it will display the list of subgenerators.
+   */
+  showRootWelcomeMessage() {
+    // When --help is used, `this.log` is not defined and `help()` is invoked by the Yeoman lib anyway.
+    if (this.options.help) return;
+
+    this.log(this.help());
   }
 
   help() {
@@ -40,9 +27,11 @@ export default class BaseGenerator extends Generator {
     ${this.subgenerators
       .map(
         (subgen) =>
-          `\t- ${globalContext.generatorScriptIdentifer}:${subgen.name} - ${subgen.description}`,
+          `\t- yo ${globalContext.generatorScriptIdentifer}:${subgen.name} - ${subgen.description}`,
       )
-      .join("\n")}`;
+      .join("\n")}
+    \nTo see usage details for a generator, use the \`--help\` flag.\n\tFor example: yo ${globalContext.generatorScriptIdentifer}:${this.subgenerators[0].name} --help  
+    `;
 
     return `${super.help()}\n${subgeneratorHelp}`;
   }


### PR DESCRIPTION
## Done

- Improves the `yo @canonical/ds --help` output by:
  - Including the entire `yo` command used to execute a subgenerator for each subgenerator. I.E., `yo @canonical/ds:component` instead of `@canonical/ds:component`
  - Including a suggestion to use the `--help` parameter for a subgenerator to see its usage instructions/parameters
- Removes the "pass-through" behavior of the root generator, where it would invoke a subgenerator by prompting or selecting the first and only subgenerator. This makes the root generator's behavior with and without `--help` consistent.

Fixes #131 
Fixes [WD-19283](https://warthogs.atlassian.net/browse/WD-19283)

## QA

- Checkout this PR
- `bun run special:clean && bun i`
- `cd packages/react/ds-core/src/ui`
- `yo @canonical/ds path/to/Button` -> outputs a list of subgenerators and usage instructions
- `yo @canonical/ds -- help` -> outputs the same as above
- `yo @canonical/ds:component path/to/Button` -> creates a button component in `src/ui/path/to/Button`

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.

## Screenshots

<img width="726" alt="Screenshot 2025-02-12 at 18 21 38" src="https://github.com/user-attachments/assets/53b0a361-0399-4c8f-b658-4ec2a0055dcb" />

