### PR TITLE
docs(react-ds-core): Create React Core ARCHITECTURE documentation and start of CONTRIBUTING documentation

### DIFF
--- a/packages/react/ds-core/ARCHITECTURE.md
+++ b/packages/react/ds-core/ARCHITECTURE.md
@@ -1,0 +1,163 @@
+## Canonical Design System - React Core - Architecture
+
+A guide to understand the design principles, key components, and technologies used in the core React component library.
+
+This document is primarily focused on providing a clear explanation of the architecture for users who
+want to understand the 'why' and 'how' behind its structure and design.
+
+## 1. Explanation: Architecture Overview
+
+### 1.1 Core Goals and Design Principles
+
+Our architecture is driven by several core goals and design principles:
+
+* **Reusable Components:** The primary goal is to create a library of reusable React components. These components are
+  designed to be building blocks for various applications, promoting consistency and efficiency in development.
+* **Design System Consistency:**  All components are built to adhere to Canonical's visual identity by default. This
+  ensures a unified and recognizable user interface across all applications that utilize this library.
+* **Accessibility First:** Accessibility is not an afterthought but a fundamental principle. Components are designed and
+  developed with accessibility best practices in mind, ensuring usability for everyone.
+* **Modern Development Practices:**  The library embraces modern development tools and practices to enhance developer
+  experience, maintainability, and performance.
+* **Maintainability and Extensibility:** The architecture is structured to be easily maintainable and extensible. The
+  styling layer can be customized or extended to accommodate different design requirements and visual variations beyond
+  the Canonical design system.
+* **Testability and Reliability:**  Robust testing is integral to the architecture, ensuring the reliability and
+  stability of the components.
+
+### 1.2 Tooling Choices
+
+This package leverages a modern JavaScript toolchain to achieve its goals:
+
+* **[React 19](https://react.dev):**: This library is built on React 19. This version of React provides the latest
+  features, performance improvements, and compatibility with the broader React ecosystem.
+* **[Vite](https://vite.dev):** Vite is used as the development server and build tool specifically for Storybook.
+  * **Fast Storybook Development Server with HMR:** Vite provides a fast development server for Storybook, enabling
+  features like Hot Module Replacement (HMR) for a smooth and efficient component development and preview experience
+  within Storybook.
+  * **Optimized Storybook Builds:** Vite is also used to build the Storybook documentation site itself, optimizing assets
+  for deployment.
+
+* **[Storybook](https://storybook.js.org/):** Storybook is employed as a development and documentation environment for
+  components:
+  * **Isolated Component Development:** Storybook allows developers to focus on individual components in isolation, making
+  development and testing more focused and efficient.
+  * **Living Style Guide and Documentation:** Storybook serves as an interactive style guide, showcasing components and
+  their variations, and automatically generating documentation.
+  * **Visual Regression Testing:** Storybook integrates well with visual regression testing tools, such
+  as [Chromatic](https://www.chromatic.com/), enabling automated visual QA of components across different states and themes.
+* **[Vitest](https://vitest.dev/)** & **[React Testing Library](https://testing-library.com/docs/react-testing-library/intro/)**
+  for user-centric unit & integration testing
+  * **Vitest:**  Vitest is selected as the test runner due to its speed, modern features, and tight integration with Vite,
+  ensuring fast and efficient testing.
+  * **React Testing Library (RTL):** RTL extends the testing environment with some of the API of `react-dom`.
+  Tests are written to simulate user interactions (e.g., clicking, typing, looking for content by context), 
+  making them more reflective of real-world usage and less likely to break due to internal implementation changes.
+* See [TESTING.md](../../../guides/TESTING.md) for more information on testing practices and guidelines.
+
+### 1.3 Component-Based Structure
+
+This package is organized around a component-based architecture. The core components reside within the `src/ui/`
+directory.
+This offers several advantages:
+
+* **Modularity and Reusability:** Components are self-contained and designed for reuse across different parts of an
+  application or across multiple projects. This modularity reduces code duplication and promotes consistency.
+* **Encapsulation and Maintainability:** Each component encapsulates its logic, styling, and tests, making it easier to
+  maintain and update individual components without causing ripple effects across the entire library.
+* **Composition and Flexibility:** Complex user interfaces can be constructed by composing simpler components. This
+  compositional approach provides flexibility and allows developers to build a wide range of UIs using the provided
+  building blocks.
+
+### 1.4 Bun Build vs. Typescript Compiler
+
+[Bun](https://bun.sh/) is being experimentally used as a package manager for this project.
+Bun includes a [native JS bundler](https://bun.sh/docs/bundler) that can transpile Typescript.
+
+We are not currently considering using `bun build` for production builds for
+the following reasons:
+
+* **Globstar inconsistencies**: Bun's [implementation of globstar](https://bun.sh/docs/api/glob) is non-standard. It is
+  difficult to build arbitrarily deep filepaths, as Bun expects a globstar for each level of supported nesting. Most
+  glob implementations treat a globstar as representing an arbitrary number of non-hidden directories. However, Bun
+  currently treats ** as a single level of nesting.
+* **Dist depth**: Generating `dist/` output that has the correct folder structure (i.e.,`dist/ui/Button/`) is
+  non-trivial. `bun build` generates output with folder structure starting from matching the shallowest source file.
+  This is not always desired. For example, if `ui/` is inside `src/`, one must `cd` into `src/` to build `ui/` into
+  `dist/`. This adds unneeded complexity to the build process.
+* **Type emitting**: `bun build` does not generate types, so it must be accompanied by the usage of some other tool that
+  generates type declarations.
+
+Ideally, we could use `bun build` for production builds, as it offers some advantages over the Typescript compiler.
+
+* **Non-TS bundling**: `bun build` copies non-TS assets (such as images, stylesheets, etc) into `dist`. `tsc` must be
+  followed up with a manual step that copies non-TS files (such as icons & css) into `dist/`. Currently, we are
+  using [copyfiles](https://npmjs.org/package/copyfiles) for this purpose.
+* **Speed**: Bun builds slightly faster than the Typescript compiler:
+
+| Tool       | Command                                                      | Real Time | User Time | Sys Time |
+|------------|--------------------------------------------------------------|-----------|-----------|----------|
+| Bun        | `bun run build:package:bun && bun run build:package:types`   | 0m0.648s  | 0m1.498s  | 0m0.117s |
+| Typescript | `bun run build:package:tsc && bun run build:package:copycss` | 0m0.707s  | 0m1.615s  | 0m0.094s |
+
+Note that the bun build must also call `tsc` to generate type declarations, and
+the tsc build must call the external `copyfiles` dependency to copy assets into
+`dist/`.
+
+For these reasons, we have chosen to use the Typescript compiler for builds, but we are open to revisiting this decision
+in the future should Bun improve on the above points.
+
+## 2. Reference: Project Structure and Configuration
+
+### 2.1 Directory Structure Breakdown
+
+The project directory structure is organized as follows:
+
+```
+react-ds-core/
+├── .storybook/             # Storybook configuration directory
+├── tsconfig.build.json  # Build-specific TypeScript configuration
+├── tsconfig.json        # Base TypeScript configuration for type-checking
+├── vite.config.ts       
+├── vitest.config.ts     
+├── vitest.setup.ts      
+├── src/                   
+│   ├── ui/                 # Root directory of all React components.
+│   │   ├── GenericComponent/ # Example component. This structure can be generated with `@canonical/generator-ds`. 
+│   │   │   ├── GenericComponent.stories.tsx # Storybook stories
+│   │   │   ├── GenericComponent.tests.tsx   # Unit tests
+│   │   │   ├── GenericComponent.tsx         # Component implementation
+│   │   │   ├── index.ts           # Exports public API of the component
+│   │   │   ├── styles.css         # Component-specific CSS styles
+│   │   │   └── types.ts         # TypeScript types for the component
+│   │   ├── AnotherComponent/  # Another Component directory (similar structure)
+│   │   │   └── ...
+│   │   └── index.ts        # Exports public API of components
+│   ├── assets/             # Static assets
+│   ├── index.css           # Global CSS styles import (from @canonical/styles)
+│   └── index.ts            # Main entry point for the library, exporting components
+├── index.html             # HTML template for Vite development server
+```
+
+### 2.2 Key Configuration Files
+
+* **`vite.config.ts`**:  Configuration for Vite, the storybook build tool.
+* **`tsconfig.json` and `tsconfig.build.json`**: TypeScript compiler configurations:
+  * **Base Configuration (`tsconfig.json`):**  Extends `@canonical/typescript-config-react`, inheriting common React
+    TypeScript settings.<br>Skips type-checking external library dependencies, as Storybook dependencies do not always
+    pass type checks.
+  * **Build Configuration (`tsconfig.build.json`):**  Specifically for creating production builds. It excludes
+    non-component runtime files (such as tests & stories) from the build artifact. External dependencies are included in
+    type-checking for increased strictness, as Storybook is excluded from this build.
+
+* **`.storybook/main.ts` and `.storybook/preview.ts`**: Storybook setup files:
+  * **`main.ts`**: Configures Storybook itself, including registering addons and specifying where Storybook should look
+    for story files (`src/**/*.stories.tsx`).<br>Leverages [
+    `@canonical/storybook-config`](../../../configs/storybook/README.md)
+    to reuse and standardize Storybook configuration across Canonical projects.
+  * **`preview.ts`**:  Customizes the Storybook preview environment. This includes using decorators to apply global
+    styles or themes to all stories.
+
+* **`vitest.config.ts` and `vitest.setup.ts`**: [Vitest](https://vitest.dev/) configuration for testing:
+  * **`vitest.config.ts`**:  Merges the base Vite configuration with Vitest-specific settings.
+  * **`vitest.setup.ts`**:  Sets up the testing environment before tests are run. 

--- a/packages/react/ds-core/CONTRIBUTING.md
+++ b/packages/react/ds-core/CONTRIBUTING.md
@@ -17,3 +17,9 @@ To create a new component, [install Yeoman](../../generator-ds/README.md), then 
 Run `yo @canonical/ds:component MyNewComponent` to generate a new component.
 You can also run `yo @canonical/ds:component --help` to see more available options, such as generating a component with a story and/or CSS file included.
 
+### Checking / Formatting / Testing
+Before committing your changes, run `bun run check:fix` to check and format your code, and automatically apply any fixable formatting changes.
+You will be alerted of any unfixable issues, which you will need to resolve manually.
+
+To test your changes, run `bun run test` to run the Vitest test suite. This will run Vitest once.
+It may also be helpful to run `bun run test:watch` to run Vitest in watch mode, which will re-run the tests when you make changes to the code.

--- a/packages/react/ds-core/CONTRIBUTING.md
+++ b/packages/react/ds-core/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+## Canonical Design System - React Core - Contribution Documentation
+
+This package provides an overview of the contribution process for the React Core package of Canonical's Design System.
+
+## Getting Started
+Follow the [repository setup](../../../guides/SETUP.md) guide to set up your development environment.
+
+Once the repository is set up, navigate to the `react/ds-core` package directory and run `bun run storybook` to start the Storybook server.
+
+Open the Storybook server at [http://localhost:6006](http://localhost:6006) to view the components and their documentation.
+
+Storybook will automatically reload when you make changes to the components, using Vite HMR.
+
+### Generating a component
+The [react component generator](../../generator-ds/src/component/README.md) provides a CLI to generate new components.
+To create a new component, [install Yeoman](../../generator-ds/README.md), then navigate to the component root directory `src/ui`. 
+Run `yo @canonical/ds:component MyNewComponent` to generate a new component.
+You can also run `yo @canonical/ds:component --help` to see more available options, such as generating a component with a story and/or CSS file included.
+

--- a/packages/react/ds-core/CONTRIBUTING.md
+++ b/packages/react/ds-core/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 This package provides an overview of the contribution process for the React Core package of Canonical's Design System.
 
 ## Getting Started
-Follow the [repository setup](../../../guides/SETUP.md) guide to set up your development environment.
+Follow the [repository setup](../../../README.md) guide to set up your development environment.
 
 Once the repository is set up, navigate to the `react/ds-core` package directory and run `bun run storybook` to start the Storybook server.
 

--- a/packages/react/ds-core/README.md
+++ b/packages/react/ds-core/README.md
@@ -1,91 +1,28 @@
-# React + TypeScript + Vite
+## Canonical Design System - React Core
 
-This template provides a minimal setup to get React working in Vite with HMR.
+This package provides the core React components and utilities for Canonical's Design System.
 
-Currently, two official plugins are available:
+## Getting Started
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) 
-  uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) 
-  uses [SWC](https://swc.rs/) for Fast Refresh
+Install the package in a React 19 project with `bun add @canonical/react-ds-core`.
 
-## Caveats
+Then, import components from the package and use them in your React components. 
+An example of a component using the `Button` component:
+```tsx
+// MyComponent.tsx
+import { Button } from "@canonical/react-ds-core";
 
-### TSConfig
+function MyComponent() {
+  return (
+    <div>
+      <Button
+        appearance={"positive"}
+        label={"Click me"}
+        onClick={() => alert("hello world!")}
+      />
+    </div>
+  );
+}
 
-#### Skip library check
-
-We use [skipLibCheck](https://www.typescriptlang.org/tsconfig/#skipLibCheck) to
-skip type checking of declaration files. This is needed for compatibility with
-storybook dependencies. If this option is not enabled, the following error occurs:
-
+export default MyComponent;
 ```
-The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("storybook/internal/types")' call instead.
-```
-
-Library checking is only disabled for Storybook files. This is due to 
-Storybook dependencies using CommonJS modules alongside ECMAScript modules, 
-which causes issues when TypeScript tries to type-check them together.
-
-Storybook files are excluded from builds in [tsconfig.build.json](tsconfig.build.json).
-Library type-checking is enabled for builds.
-
-
-### Bun
-
-[Bun](https://bun.sh/) is being experimentally used as a package manager.
-
-### Build tool
-
-Bun includes a [native JS bundler](https://bun.sh/docs/bundler) that can 
-transpile Typescript.
-
-#### Downsides
-
-We are not currently considering using `bun build` for production builds for 
-the following reasons:
-
-##### Globstar
-
-Bun's [implementation of globstar](https://bun.sh/docs/api/glob) is non-standard.
-It is difficult to build arbitrarily deep filepaths, as Bun expects a globstar 
-for each level of supported nesting. Most glob implementations treat a globstar 
-as representing an arbitrary number of non-hidden directories. However, with 
-Bun, matching `.ts` files in `src/ui/Button` requires the glob pattern 
-`**/**/*.ts`, which does not match files in other levels of nesting.
-
-##### Dist Depth
-
-Generating `dist/` output that has the correct folder structure (i.e., 
-`dist/ui/Button/`) is non-trivial. `bun build` generates output with folder 
-structure starting from matching the shallowest source file. However, this is 
-not always desired. For example, if `ui/` is inside `src/`, one must `cd` into 
-`src` before running `bun build` to generate the appropriate folder structure. 
-You must then set build output to `../dist` to place build results in the 
-project root. This makes the build script unnecessarily complex.
-
-##### Type emitting
-
-`bun build` does not generate types, so it must be accompanied by the usage of 
-some other tool that generates type declarations.
-
-#### Upsides
-
-##### Speed
-
-Bun builds slightly faster than the Typescript compiler.
-
-| Tool | Command                                                             | Real Time | User Time | Sys Time |
-| ---- | --------------------------------------------------------------------| --------- | --------- | -------- |
-| Bun  | `bun run build:package:bun`                                         | 0m0.648s  | 0m1.498s  | 0m0.117s |
-| Typescript  | `bun run build:package:tsc && bun run build:package:copycss` | 0m0.707s  | 0m1.615s  | 0m0.094s |
-
-Note that the bun build must also call `tsc` to generate type declarations, and 
-the tsc build must call the external `copyfiles` dependency to copy assets into 
-`dist/`.
-
-##### Non-TS bundling
-
-`bun build` copies non-TS assets (such as images, stylesheets, etc) into `dist`. 
-`tsc` must be followed up with a manual step that copies non-TS files (currently, 
-this is only CSS) into `dist`.


### PR DESCRIPTION
## Done

- Creates `ARCHITECTURE.md` for the DS core package
- Removes details from `README.md` that are now covered in `ARCHITECTURE.md`
- Updates `README.md` with some instructions on setting up the package.
- Adds a small (starter) `CONTRIBUTING.md` file for the React DS core, covering some key contributor tasks

## QA

- coming soon

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.
