### PR TITLE
fix(React Core): Popups close on Escape, disabled elements will not trigger popups to open

### DIFF
--- a/packages/react/ds-core/src/ui/hooks/usePopup/types.ts
+++ b/packages/react/ds-core/src/ui/hooks/usePopup/types.ts
@@ -29,6 +29,10 @@ export interface UsePopupProps
   closeOnEscape?: boolean;
 }
 
+export type DisableableElement = HTMLElement & {
+  disabled: boolean;
+};
+
 export interface UsePopupResult extends UseWindowFitmentResult {
   /**
    * A ref to be attached to the target element.

--- a/packages/react/ds-core/src/ui/hooks/usePopup/types.ts
+++ b/packages/react/ds-core/src/ui/hooks/usePopup/types.ts
@@ -25,6 +25,8 @@ export interface UsePopupProps
   onShow?: (event?: Event) => void;
   /** A callback to be called when the popup is hidden. */
   onHide?: (event?: Event) => void;
+  /** Whether the popup should close when the escape key is pressed. Defaults to true. */
+  closeOnEscape?: boolean;
 }
 
 export interface UsePopupResult extends UseWindowFitmentResult {

--- a/packages/react/ds-core/src/ui/hooks/usePopup/usePopup.tests.tsx
+++ b/packages/react/ds-core/src/ui/hooks/usePopup/usePopup.tests.tsx
@@ -103,14 +103,14 @@ describe("usePopup", () => {
     const { result } = renderHook(() => usePopup({}));
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to FocusEvent type
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to PointerEvent type
       result.current.handleTriggerEnter({ nativeEvent: {} } as any);
     });
 
     expect(activate).toHaveBeenCalledTimes(1);
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to FocusEvent type
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to PointerEvent type
       result.current.handleTriggerLeave({ nativeEvent: {} } as any);
     });
 
@@ -135,21 +135,21 @@ describe("usePopup", () => {
     expect(onFocus).toHaveBeenCalledTimes(1);
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to FocusEvent type
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to PointerEvent type
       result.current.handleTriggerBlur({ nativeEvent: {} } as any);
     });
 
     expect(onBlur).toHaveBeenCalledTimes(1);
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to FocusEvent type
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to PointerEvent type
       result.current.handleTriggerEnter({ nativeEvent: {} } as any);
     });
 
     expect(onEnter).toHaveBeenCalledTimes(1);
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to FocusEvent type
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to PointerEvent type
       result.current.handleTriggerLeave({ nativeEvent: {} } as any);
     });
 
@@ -171,5 +171,31 @@ describe("usePopup", () => {
     expect(vi.mocked(useWindowFitment)).toHaveBeenCalledWith({
       isOpen: true,
     });
+  });
+
+  it("should close the popup when the Escape key is pressed", async () => {
+    const deactivate = vi.fn();
+    const activate = vi.fn();
+    vi.mocked(useDelayedToggle).mockReturnValue({
+      flag: false,
+      activate,
+      deactivate,
+    });
+
+    const { result } = renderHook(() => usePopup({}));
+
+    act(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to FocusEvent type
+      result.current.handleTriggerFocus({ nativeEvent: {} } as any);
+    });
+
+    expect(activate).toHaveBeenCalledOnce();
+
+    act(() => {
+      const event = new KeyboardEvent("keydown", { key: "Escape" });
+      document.dispatchEvent(event);
+    });
+
+    expect(deactivate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react/ds-core/src/ui/hooks/usePopup/usePopup.tests.tsx
+++ b/packages/react/ds-core/src/ui/hooks/usePopup/usePopup.tests.tsx
@@ -75,7 +75,7 @@ describe("usePopup", () => {
     const { result } = renderHook(() => usePopup({}));
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to FocusEvent type
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test event without the test data conforming to FocusEvent type
       result.current.handleTriggerFocus({ nativeEvent: {} } as any);
     });
 
@@ -83,7 +83,7 @@ describe("usePopup", () => {
     expect(result.current.isFocused).toBe(true);
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to FocusEvent type
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test event without the test data conforming to FocusEvent type
       result.current.handleTriggerBlur({ nativeEvent: {} } as any);
     });
 
@@ -103,15 +103,15 @@ describe("usePopup", () => {
     const { result } = renderHook(() => usePopup({}));
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to PointerEvent type
-      result.current.handleTriggerEnter({ nativeEvent: {} } as any);
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test event without the test data conforming to PointerEvent type
+      result.current.handleTriggerEnter({} as any);
     });
 
     expect(activate).toHaveBeenCalledTimes(1);
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to PointerEvent type
-      result.current.handleTriggerLeave({ nativeEvent: {} } as any);
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test event without the test data conforming to PointerEvent type
+      result.current.handleTriggerLeave({} as any);
     });
 
     expect(deactivate).toHaveBeenCalledTimes(1);
@@ -128,29 +128,29 @@ describe("usePopup", () => {
     );
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to FocusEvent type
-      result.current.handleTriggerFocus({ nativeEvent: {} } as any);
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test event without the test data conforming to FocusEvent type
+      result.current.handleTriggerFocus({} as any);
     });
 
     expect(onFocus).toHaveBeenCalledTimes(1);
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to PointerEvent type
-      result.current.handleTriggerBlur({ nativeEvent: {} } as any);
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test event without the test data conforming to PointerEvent type
+      result.current.handleTriggerBlur({} as any);
     });
 
     expect(onBlur).toHaveBeenCalledTimes(1);
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to PointerEvent type
-      result.current.handleTriggerEnter({ nativeEvent: {} } as any);
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test event without the test data conforming to PointerEvent type
+      result.current.handleTriggerEnter({} as any);
     });
 
     expect(onEnter).toHaveBeenCalledTimes(1);
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to PointerEvent type
-      result.current.handleTriggerLeave({ nativeEvent: {} } as any);
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test event without the test data conforming to PointerEvent type
+      result.current.handleTriggerLeave({} as any);
     });
 
     expect(onLeave).toHaveBeenCalledTimes(1);
@@ -185,8 +185,8 @@ describe("usePopup", () => {
     const { result } = renderHook(() => usePopup({}));
 
     act(() => {
-      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test focus event without the test data conforming to FocusEvent type
-      result.current.handleTriggerFocus({ nativeEvent: {} } as any);
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test event without the test data conforming to FocusEvent type
+      result.current.handleTriggerFocus({} as any);
     });
 
     expect(activate).toHaveBeenCalledOnce();
@@ -197,5 +197,24 @@ describe("usePopup", () => {
     });
 
     expect(deactivate).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not open the popup on hover (trigger enter) if the trigger is disabled", () => {
+    const activate = vi.fn();
+    const deactivate = vi.fn();
+    vi.mocked(useDelayedToggle).mockReturnValue({
+      flag: false,
+      activate,
+      deactivate,
+    });
+
+    const { result } = renderHook(() => usePopup({}));
+
+    act(() => {
+      // biome-ignore lint/suspicious/noExplicitAny: Allow firing a test event without the test data conforming to PointerEvent type
+      result.current.handleTriggerEnter({ target: { disabled: true } } as any);
+    });
+
+    expect(activate).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/ds-core/src/ui/hooks/usePopup/usePopup.ts
+++ b/packages/react/ds-core/src/ui/hooks/usePopup/usePopup.ts
@@ -2,6 +2,7 @@ import {
   type FocusEventHandler,
   type PointerEventHandler,
   useCallback,
+  useEffect,
   useId,
 } from "react";
 import { useState } from "react";
@@ -20,6 +21,7 @@ import type { UsePopupProps, UsePopupResult } from "./types.js";
  * @param onBlur A callback to be called when the target element loses focus.
  * @param onShow A callback to be called when the popup is shown.
  * @param onHide A callback to be called when the popup is hidden.
+ * @param closeOnEscape Whether the popup should close when the escape key is pressed. Defaults to true.
  * @param props The props to be passed to the useWindowFitment hook.
  * @returns The current state of the popup, and event handlers for the target element.
  */
@@ -33,6 +35,7 @@ const usePopup = ({
   onBlur,
   onShow,
   onHide,
+  closeOnEscape = true,
   ...props
 }: UsePopupProps): UsePopupResult => {
   const [isFocused, setIsFocused] = useState(false);
@@ -91,6 +94,22 @@ const usePopup = ({
     },
     [close, onLeave],
   );
+
+  useEffect(() => {
+    if (!closeOnEscape) return;
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        close(event);
+      }
+    };
+
+    document.addEventListener("keydown", handleEscape);
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [close, closeOnEscape]);
 
   return {
     handleTriggerBlur,

--- a/packages/react/ds-core/src/ui/hooks/usePopup/usePopup.ts
+++ b/packages/react/ds-core/src/ui/hooks/usePopup/usePopup.ts
@@ -8,7 +8,11 @@ import {
 import { useState } from "react";
 import { useDelayedToggle } from "../useDelayedToggle/index.js";
 import { useWindowFitment } from "../useWindowFitment/index.js";
-import type { UsePopupProps, UsePopupResult } from "./types.js";
+import type {
+  DisableableElement,
+  UsePopupProps,
+  UsePopupResult,
+} from "./types.js";
 
 /**
  * Manages the state of a popup.
@@ -79,20 +83,24 @@ const usePopup = ({
     [close, onBlur],
   );
 
+  const isDisabled = useCallback((el: DisableableElement) => el?.disabled, []);
+
   const handleTriggerEnter: PointerEventHandler = useCallback(
     (event) => {
+      if (isDisabled(event.target as DisableableElement)) return;
       open(event.nativeEvent);
       if (onEnter) onEnter(event);
     },
-    [open, onEnter],
+    [open, onEnter, isDisabled],
   );
 
   const handleTriggerLeave: PointerEventHandler = useCallback(
     (event) => {
+      if (isDisabled(event.target as DisableableElement)) return;
       close(event.nativeEvent);
       if (onLeave) onLeave(event);
     },
-    [close, onLeave],
+    [close, onLeave, isDisabled],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Done

Minor UX & A11y fixes for the `usePopup` hook.

- Fulfills [WCAG requirement to close popups on Escape keypress](https://www.w3.org/WAI/WCAG21/Understanding/content-on-hover-or-focus.html)
- Popups are no longer triggered when a disabled target element is hovered.

## QA

- Clone this PR.
- Open any tooltip example.
- Use tab to focus a tooltip, see that the tooltip message appears.
- Press Escape, verify the tooltip closes.
- Modify any tooltip story with a Button element, by disabling the button trigger element.
- Hover the disabled button, verify that the tooltip does not open.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.
