### PR TITLE
fix(React Core): UseWindowDimension is SSR-safe

### DIFF
--- a/apps/react/boilerplate-vite/src/Application.tsx
+++ b/apps/react/boilerplate-vite/src/Application.tsx
@@ -1,4 +1,4 @@
-import { Button } from "@canonical/react-ds-core";
+import { Button, TooltipArea } from "@canonical/react-ds-core";
 import React, { Suspense, useState, lazy } from "react";
 import canonicalLogo from "./assets/canonical.svg";
 import reactLogo from "./assets/react.svg";
@@ -36,10 +36,15 @@ function App() {
         <LazyButton />
       </Suspense>
       <div className="card">
-        <Button
-          label={`Count: ${count}`}
-          onClick={() => setCount((count) => count + 1)}
-        />
+        <TooltipArea
+          preferredDirections={["right", "bottom"]}
+          Message={`Increment count to ${count + 1}`}
+        >
+          <Button
+            label={`Count: ${count}`}
+            onClick={() => setCount((count) => count + 1)}
+          />
+        </TooltipArea>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>

--- a/packages/react/ds-core/src/ui/hooks/useWindowDimensions/useWindowDimensions.ts
+++ b/packages/react/ds-core/src/ui/hooks/useWindowDimensions/useWindowDimensions.ts
@@ -15,10 +15,16 @@ export default function useWindowDimensions({
   scrollDelay = 100,
 }: UseWindowDimensionProps = {}): UseWindowDimensionsResult {
   const isServer = typeof window === "undefined";
-  const [windowWidth, setWindowWidth] = useState(window.innerWidth);
-  const [windowHeight, setWindowHeight] = useState(window.innerHeight);
-  const [scrollHeight, setScrollHeight] = useState(window.scrollY);
-  const [scrollWidth, setScrollWidth] = useState(window.scrollX);
+  const [windowWidth, setWindowWidth] = useState(
+    isServer ? 0 : window.innerWidth,
+  );
+  const [windowHeight, setWindowHeight] = useState(
+    isServer ? 0 : window.innerHeight,
+  );
+  const [scrollHeight, setScrollHeight] = useState(
+    isServer ? 0 : window.scrollY,
+  );
+  const [scrollWidth, setScrollWidth] = useState(isServer ? 0 : window.scrollX);
 
   const result = useMemo(
     () => ({


### PR DESCRIPTION
## Done

#151 updated `useWindowDimension` to no longer short-circuit return in SSR. However, while POC'ing something for the demo site, I noticed my builds failing as the window dimensions were initialized using `window`, even on the server.

This updates the hook to use `0` as the default for each dimension when in an SSR environment. It also uses the `TooltipArea` inside the boilerplate project to enable us to test for SSR build / hydration errors caused by the Tooltip stack.

## QA

- Checkout this PR
- `cd apps/react/boilerplate-vite`
- `bun run serve`
- Verify that the tooltip on the "count" button renders correctly
- Verify that no hydration errors are thrown in the console.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.
