### PR TITLE
fix: remove flexbox from EditableContent content section

### DIFF
--- a/packages/react/ds-app-launchpad/src/ui/EditableBlock/styles.css
+++ b/packages/react/ds-app-launchpad/src/ui/EditableBlock/styles.css
@@ -34,8 +34,5 @@
 
   > .content {
     flex-grow: 1;
-    display: flex;
-    justify-content: center;
-    align-items: center;
   }
 }


### PR DESCRIPTION
## Done

remove flexbox from EditableContent content section

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.


## Screenshots

### Before: 
![image](https://github.com/user-attachments/assets/51654216-22d5-4697-a718-bd38d02ed754)

### After:
![image](https://github.com/user-attachments/assets/f1c043ae-7e4a-482e-ba37-5b5108f1834f)
