### PR TITLE
feat(React core): Add tooltip autofit

### DIFF
--- a/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
+++ b/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
@@ -105,3 +105,16 @@ export const Inline: StoryFn = () => {
     </p>
   );
 };
+
+export const AutoFit: StoryFn = () => {
+  return (
+    <Component
+      Message={"This is autofit"}
+      preferredDirections={["top"]}
+      autoFit={true}
+      style={{ position: "absolute", bottom: 0, left: 0 }}
+    >
+      <Button label={"Autofit"} />
+    </Component>
+  );
+};

--- a/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.tsx
+++ b/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.tsx
@@ -15,6 +15,8 @@ const componentCssClassName = "ds tooltip-area";
  */
 const TooltipArea = ({
   children,
+  style,
+  className,
   Message,
   distance = "6px",
   targetElementId,
@@ -23,6 +25,7 @@ const TooltipArea = ({
   messageElementClassName,
   messageElementStyle,
   parentElement,
+  autoFit,
   ...props
 }: TooltipAreaProps): ReactElement => {
   const {
@@ -36,12 +39,16 @@ const TooltipArea = ({
     handleTriggerEnter,
     handleTriggerLeave,
     bestPosition,
-  } = usePopup({ distance, ...props });
+  } = usePopup({ distance, autoFit, ...props });
 
   const TooltipMessageElement = (
     <Tooltip
       id={popupId}
-      className={[bestPosition?.positionName, messageElementClassName]
+      className={[
+        bestPosition?.positionName,
+        messageElementClassName,
+        autoFit && "autofit",
+      ]
         .filter(Boolean)
         .join(" ")}
       onPointerEnter={handleTriggerEnter}
@@ -52,6 +59,11 @@ const TooltipArea = ({
         ...popupPositionStyle,
         // @ts-ignore allow binding arrow size to distance, as it is needed both in JS and CSS calculations
         "--tooltip-spacing-arrow-size": distance,
+        ...(autoFit &&
+          bestPosition?.autoFitOffset && {
+            "--tooltip-arrow-offset-top": `${bestPosition?.autoFitOffset.top || 0}px`,
+            "--tooltip-arrow-offset-left": `${bestPosition?.autoFitOffset.left || 0}px`,
+          }),
       }}
       isOpen={isOpen}
     >
@@ -61,7 +73,8 @@ const TooltipArea = ({
 
   return (
     <span
-      className={[componentCssClassName].filter(Boolean).join(" ")}
+      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      style={style}
       onFocus={handleTriggerFocus}
       onBlur={handleTriggerBlur}
       onPointerEnter={handleTriggerEnter}
@@ -69,7 +82,8 @@ const TooltipArea = ({
     >
       <span
         id={targetElementId}
-        className={["target"].filter(Boolean).join(" ")}
+        style={targetElementStyle}
+        className={["target", targetElementClassName].filter(Boolean).join(" ")}
         ref={targetRef}
         aria-describedby={popupId}
       >

--- a/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/types.ts
+++ b/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/types.ts
@@ -11,6 +11,10 @@ export interface TooltipAreaProps extends UsePopupProps {
    * The content of the tooltip. This can be a string or any valid React node.
    */
   Message: ReactNode;
+  /** Styles applied to the tooltip area */
+  style?: CSSProperties;
+  /** Class name applied to the tooltip area */
+  className?: string;
   /** ID applied to the target element */
   targetElementId?: string;
   /** Class name applied to the target element */

--- a/packages/react/ds-core/src/ui/Tooltip/styles.css
+++ b/packages/react/ds-core/src/ui/Tooltip/styles.css
@@ -18,6 +18,9 @@
     --tooltip-line-height: line height of the tooltip
 
     --tooltip-spacing-arrow-size: size of the arrow
+
+    --tooltip-arrow-offset-left: offset of the arrow from the left
+    --tooltip-arrow-offset-top: offset of the arrow from the top
 */
 
 .ds.tooltip {
@@ -68,6 +71,13 @@
     opacity: 1;
     pointer-events: auto;
     visibility: visible;
+  }
+
+  &.autofit {
+    &::before {
+      transform: translateX(var(--tooltip-arrow-offset-left))
+        translateY(var(--tooltip-arrow-offset-top));
+    }
   }
 
   /* triangle */

--- a/packages/react/ds-core/src/ui/hooks/usePopup/usePopup.tests.tsx
+++ b/packages/react/ds-core/src/ui/hooks/usePopup/usePopup.tests.tsx
@@ -19,6 +19,7 @@ describe("usePopup", () => {
     positionName: "bottom",
     position: { top: 10, left: 20 },
     fits: true,
+    autoFitOffset: { top: 0, left: 0 },
   };
 
   const mockPopupPositionStyle: CSSProperties = {

--- a/packages/react/ds-core/src/ui/hooks/useWindowFitment/types.ts
+++ b/packages/react/ds-core/src/ui/hooks/useWindowFitment/types.ts
@@ -2,6 +2,12 @@ import type { CSSProperties, RefObject } from "react";
 
 export interface UseWindowFitmentProps {
   /**
+   * Whether the popup should automatically fit into the viewport.
+   * If true, the hook will try to fit the popup into the viewport if it doesn't fit in the preferred directions.
+   * Defaults to false.
+   */
+  autoFit?: boolean;
+  /**
    * An array of preferred directions for the popup.
    * The hook will try to position the popup in these directions in order.
    * Defaults to ['top', 'bottom', 'left', 'right'].
@@ -76,4 +82,5 @@ export interface BestPosition {
   position: RelativePosition;
   positionName: WindowFitmentDirection;
   fits: boolean;
+  autoFitOffset: RelativePosition;
 }


### PR DESCRIPTION
## Done

Adds `autoFit` support for the tooltip component. A need for this was noticed while working on the demo site, where a tooltipped button is in the bottom left corner, causing an overflowing tooltip in most cases.

## QA

- Checkout this PR
- Open the "autofit" tooltipArea story in the DS react core storybook
- Verify that the tooltip is constrained to fit within the window

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.

## Screenshots

<img width="228" alt="Screenshot 2025-03-19 at 22 08 23" src="https://github.com/user-attachments/assets/ce36ccba-3d7b-4734-b15a-f2d11a62c816" />

