### PR TITLE
fix(React core): Popup placement accounts for target margin, target m…

### DIFF
--- a/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/styles.css
+++ b/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/styles.css
@@ -4,10 +4,5 @@
     cursor: pointer;
     position: relative;
     display: inline-block;
-
-    & > * {
-      /* The tooltip targets must have no margin in order for tooltip placements to work correctly */
-      margin: 0 !important;
-    }
   }
 }

--- a/packages/react/ds-core/src/ui/hooks/useWindowFitment/useWindowFitment.tsx
+++ b/packages/react/ds-core/src/ui/hooks/useWindowFitment/useWindowFitment.tsx
@@ -61,6 +61,42 @@ const useWindowFitment = ({
   }, [gutter, windowDimensions, isServer]);
 
   /**
+   * Gets the internal sizing of an element.
+   * The internal sizing of an element is the maximum bounding client rect of its children.
+   * This is useful for obtaining the internal dimensions of an element that may have padding or margins.
+   * In the window fitment case, it allows us to determine how much space a target element's children take up,
+   * without accounting for margin or padding on the target element itself.
+   * This allows us to position popups relative to the target element, without needing to modify its margin or padding.
+   * @param parentElement The parent element to get the internal sizing of.
+   * @returns The internal sizing of the parent element.
+   */
+  const getInternalSizing = useCallback(
+    (parentElement: HTMLElement): DOMRect => {
+      if (!parentElement || !parentElement.children.length) {
+        return new DOMRect(0, 0, 0, 0);
+      }
+
+      let minX = Number.POSITIVE_INFINITY;
+      let minY = Number.POSITIVE_INFINITY;
+      let maxX = Number.NEGATIVE_INFINITY;
+      let maxY = Number.NEGATIVE_INFINITY;
+
+      const children = Array.from(parentElement.children);
+
+      for (const child of children) {
+        const childRect = child.getBoundingClientRect();
+        minX = Math.min(minX, childRect.left);
+        minY = Math.min(minY, childRect.top);
+        maxX = Math.max(maxX, childRect.right);
+        maxY = Math.max(maxY, childRect.bottom);
+      }
+
+      return new DOMRect(minX, minY, maxX - minX, maxY - minY);
+    },
+    [],
+  );
+
+  /**
    * Calculate the relative position of the popup when oriented in a given direction.
    * @param direction The side of the target element to position the popup on.
    * @param targetRect The bounding client rect of the target element.
@@ -236,13 +272,14 @@ const useWindowFitment = ({
       targetSize
     )
       return findBestPosition(
-        targetRef.current.getBoundingClientRect(),
+        getInternalSizing(targetRef.current),
         popupRef.current.getBoundingClientRect(),
         preferredDirections,
       );
   }, [
     findBestPosition,
     preferredDirections,
+    getInternalSizing,
     windowDimensions,
     popupSize,
     targetSize,


### PR DESCRIPTION
To correctly position the tooltip and avoid disrupting the flow of content by ignoring target margins, I have adjusted the `useWindowFitment` hook to consider the **internal** sizing (the bounding box of the target's children, rather than the target itself) for positioning calculations.

## Done

Fixes #168 

## QA

- Checkout PR
- Open React Core storybook
- See that the buttons in the tooltip examples have the expected button margin, and the tooltips are still correctly positioned.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.

## Screenshots

<img width="347" alt="Screenshot 2025-03-20 at 16 39 13" src="https://github.com/user-attachments/assets/b53fab82-bdc1-4b53-9751-98f0f48f493b" />

<img width="249" alt="Screenshot 2025-03-20 at 16 52 02" src="https://github.com/user-attachments/assets/e8ee6d43-f8b7-48e3-b55e-ebfbc51b6b70" />
