### PR TITLE
fix(Tooltip): Tooltips use `position: fixed`

### DIFF
--- a/packages/react/ds-core/src/ui/Tooltip/styles.css
+++ b/packages/react/ds-core/src/ui/Tooltip/styles.css
@@ -59,7 +59,7 @@
   pointer-events: auto;
   display: inline-block;
   transition: opacity 0.1s ease-in-out;
-  position: absolute;
+  position: fixed;
 
   &[aria-hidden="true"] {
     opacity: 0;


### PR DESCRIPTION
## Done

Fixes an issue where tooltips were positioned relative to their parent element, rather than the viewport. This caused the tooltip to be in the incorrect position when the tooltip parent's context has been scrolled.

## QA

1. Visit [demo site showcase example](https://67e2cffc51800d09d0f838fd-cbxiksavjt.chromatic.com/iframe.html?args=&globals=&id=showcase--default&viewMode=story).
2. Hover the configure button and verify it's in the correct position.
3. Scroll the Typographic specimen down.
4. Hover the configure button again, see that it's positioned too high.
5. Inspect the tooltip element and change its position to `fixed`.
6. Repeat step 2, see that the tooltip is now in the correct position, regardless of scroll.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.

## Screenshots

Before:
<img width="371" alt="Screenshot 2025-03-25 at 15 39 14" src="https://github.com/user-attachments/assets/156c87ff-a1a1-4a49-911b-0fcd13bf4632" />

After:
<img width="371" alt="Screenshot 2025-03-25 at 15 39 28" src="https://github.com/user-attachments/assets/1a3667fe-d367-4851-bf9d-cecab50fe02a" />
