### PR TITLE
feat: add readonly mode to the editable block component

### DIFF
--- a/packages/react/ds-app-launchpad/src/ui/MarkdownEditor/MarkdownEditor.stories.tsx
+++ b/packages/react/ds-app-launchpad/src/ui/MarkdownEditor/MarkdownEditor.stories.tsx
@@ -22,6 +22,14 @@ export const Default: Story = {
   },
 };
 
+export const WithCheckboxPreviewSwitch: Story = {
+  args: {
+    previewSwitchMode: "checkbox",
+    placeholder: "Add a comment here...",
+    rows: 5,
+  },
+};
+
 export const ReadOnlyMarkdownViewer: Story = {
   args: {
     hideToolbar: true,

--- a/packages/react/ds-app-launchpad/src/ui/MarkdownEditor/MarkdownEditor.tests.tsx
+++ b/packages/react/ds-app-launchpad/src/ui/MarkdownEditor/MarkdownEditor.tests.tsx
@@ -91,4 +91,10 @@ describe("MarkdownEditor", () => {
       expect(handleEditModeChange).toHaveBeenCalledWith("preview");
     });
   });
+
+  it("shows a checkbox to switch between write and preview modes", () => {
+    render(<MarkdownEditor previewSwitchMode="checkbox" />);
+
+    expect(screen.getByRole("checkbox")).toBeInTheDocument();
+  });
 });

--- a/packages/react/ds-app-launchpad/src/ui/MarkdownEditor/MarkdownEditor.tsx
+++ b/packages/react/ds-app-launchpad/src/ui/MarkdownEditor/MarkdownEditor.tsx
@@ -1,8 +1,7 @@
 import hljs from "highlight.js";
-/* @canonical/generator-ds 0.9.0-experimental.4 */
-import { forwardRef } from "react";
 import type React from "react";
 import {
+  forwardRef,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -43,6 +42,7 @@ const MarkdownEditor = forwardRef(
       placeholder,
       hideToolbar = false,
       hidePreview = false,
+      previewSwitchMode = "tab",
       borderless = false,
       editMode: controlledEditMode,
       onEditModeChange: controlledOnEditModeChange,
@@ -134,7 +134,7 @@ const MarkdownEditor = forwardRef(
           .join(" ")}
       >
         <div className="top-bar">
-          {!hidePreview && (
+          {!hidePreview && previewSwitchMode === "tab" && (
             <ViewModeTabs
               editMode={editMode}
               onEditModeChange={handleEditModeChange}
@@ -204,6 +204,22 @@ const MarkdownEditor = forwardRef(
                 </Toolbar.Button>
               </Toolbar.Group>
             </Toolbar>
+          )}
+          {!hidePreview && previewSwitchMode === "checkbox" && (
+            <div className="preview-switch">
+              <input
+                type="checkbox"
+                id={`${id}-preview-switch`}
+                checked={editMode === "preview"}
+                onChange={(e) => {
+                  handleEditModeChange(
+                    e.target.checked ? "preview" : "write",
+                    "click",
+                  );
+                }}
+              />
+              <label htmlFor={`${id}-preview-switch`}>Preview</label>
+            </div>
           )}
         </div>
 

--- a/packages/react/ds-app-launchpad/src/ui/MarkdownEditor/styles.css
+++ b/packages/react/ds-app-launchpad/src/ui/MarkdownEditor/styles.css
@@ -4,6 +4,8 @@
   --markdown-editor-editor-color: black;
   --markdown-editor-editor-border-color: #7b7b7b;
 
+  --markdown-editor-top-bar-background-color: white;
+
   --markdown-editor-tabs-hover-color: black;
   --markdown-editor-tabs-hover-background-color: #f2f2f2;
   --markdown-editor-tabs-inactive-color: #737373;
@@ -32,6 +34,18 @@
     align-items: center;
     flex-wrap: nowrap;
     margin-bottom: -1px;
+    background-color: var(--markdown-editor-top-bar-background-color);
+
+    > .preview-switch {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      font-size: 0.75rem;
+      font-weight: 550;
+      cursor: pointer;
+      padding: var(--markdown-editor-toolbar-vert-padding)
+        var(--markdown-editor-toolbar-horizontal-padding);
+    }
   }
 
   & > .editor-content {

--- a/packages/react/ds-app-launchpad/src/ui/MarkdownEditor/types.ts
+++ b/packages/react/ds-app-launchpad/src/ui/MarkdownEditor/types.ts
@@ -31,7 +31,9 @@ export type MarkdownEditorProps = {
   textareaStyle?: React.CSSProperties;
   /** Preview pane styles */
   previewStyle?: React.CSSProperties;
-
+  /** Control how the switch to preview mode looks */
+  previewSwitchMode?: "tab" | "checkbox";
+  /** On preview pane overflow, show a button to expand the preview pane */
   emptyInputMessage?: string;
   toolbarBarLabelMessage?: string;
   ToolbarTextFormattingGroupLabelMessage?: string;


### PR DESCRIPTION
## Done

Add checkbox preview switch to MarkdownEditor component


### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.


## Screenshots
![image](https://github.com/user-attachments/assets/2a3d190a-e007-4cd1-95a1-96fcb0b94697)

