### PR TITLE
fix(Demo site): Fix initial CSS state not being correcty set to defaults

### DIFF
--- a/apps/react/demo/src/hooks/useExampleRHFInterface/useExampleRHFInterface.ts
+++ b/apps/react/demo/src/hooks/useExampleRHFInterface/useExampleRHFInterface.ts
@@ -30,11 +30,16 @@ const useExampleRHFInterface = (): useGlobalFormResult => {
 
   const defaultValues = useMemo(
     () =>
-      examples.reduce((acc, example) => {
-        for (const field of example.fields) {
-          acc[field.name] = field.defaultValue;
-        }
-        return acc;
+      examples.reduce((exampleAcc, example) => {
+        // Top level of the default values is a dictionary of example names to their sets of fields
+        exampleAcc[example.name] = example.fields.reduce((fieldAcc, field) => {
+          // Second level of the default values is a set of fields and default values for each field
+          const { [ORIGINAL_VAR_NAME_KEY]: fieldName } = field;
+          if (!fieldName) return fieldAcc;
+          fieldAcc[fieldName] = field.defaultValue;
+          return fieldAcc;
+        }, {} as FormState);
+        return exampleAcc;
       }, {} as FormState),
     [examples],
   );

--- a/apps/react/demo/src/ui/Showcase/common/Example/common/Renderer/Renderer.tsx
+++ b/apps/react/demo/src/ui/Showcase/common/Example/common/Renderer/Renderer.tsx
@@ -1,17 +1,11 @@
 import type { RendererProps } from "./types.js";
-
 const componentCssClassname = "ds example-renderer";
 import root from "react-shadow";
-
-import { useWatch } from "react-hook-form";
-import { toGlobalFormStateKey } from "utils/index.js";
 import { useConfig } from "../../hooks/index.js";
 import shadowCss from "./shadow-styles.css?raw";
 
 const Renderer = ({ style, className }: RendererProps) => {
-  const { activeExample, output } = useConfig();
-  const { [toGlobalFormStateKey(activeExample.name)]: componentConfigState } =
-    useWatch();
+  const { activeExample, output, activeExampleSettings } = useConfig();
 
   return (
     <div
@@ -24,7 +18,7 @@ const Renderer = ({ style, className }: RendererProps) => {
         <root.div style={output.css} mode={"closed"}>
           <style>{shadowCss}</style>
           <div className="ds shadow-container">
-            <activeExample.Component {...componentConfigState} />
+            <activeExample.Component {...activeExampleSettings} />
           </div>
         </root.div>
       )}

--- a/apps/react/demo/src/ui/Showcase/common/Example/hooks/useProviderState.ts
+++ b/apps/react/demo/src/ui/Showcase/common/Example/hooks/useProviderState.ts
@@ -75,13 +75,23 @@ const useProviderState = ({
     [output],
   );
 
+  /** The settings for the active example */
+  const activeExampleSettings = useMemo(
+    () => formState[activeExample.name],
+    [formState, activeExample],
+  );
+
   useEffect(() => {
     // When the active example changes, set the form values to the new example's values
-    for (const control of activeExample.fields) {
-      const { name: formStateKey } = control;
+    for (const field of activeExample.fields) {
+      const { name: formStateKey, [ORIGINAL_VAR_NAME_KEY]: originalFieldName } =
+        field;
       const curVal = getValues(formStateKey);
-      const setValTo =
-        curVal !== undefined ? curVal : defaultValues[formStateKey];
+      let setValTo = curVal;
+      // Fallback to default value if value is being cleared
+      if ((setValTo === undefined || setValTo === null) && originalFieldName) {
+        setValTo = defaultValues[activeExample.name]?.[originalFieldName];
+      }
       if (curVal !== setValTo) {
         setValue(formStateKey, setValTo);
       }
@@ -98,6 +108,7 @@ const useProviderState = ({
       activatePrevExample,
       activateNextExample,
       output,
+      activeExampleSettings,
     }),
     [
       activeExampleIndex,
@@ -107,6 +118,7 @@ const useProviderState = ({
       activatePrevExample,
       activateNextExample,
       output,
+      activeExampleSettings,
     ],
   );
 };

--- a/apps/react/demo/src/ui/Showcase/common/Example/types.ts
+++ b/apps/react/demo/src/ui/Showcase/common/Example/types.ts
@@ -25,6 +25,8 @@ export interface ContextOptions {
   activatePrevExample: () => void;
   /** Switches to the next example */
   activateNextExample: () => void;
+  /** The settings for the current active example */
+  activeExampleSettings: FormState;
 }
 
 /** The context provider props for the config provider */


### PR DESCRIPTION
## Done

- Fixes an issue where demo site examples were not being properly set to the default settings until after the form state was modified the first time. The `defaultValues` dictionary was being constructed as a flat dictionary of `ExampleName.controlName: defaultValue` entries. It needs to be a nested dictionary of `ExampleName: { controlName: defaultValue }`.
- Simplifies the passing of active example settings to showcase examples by exposing `activeExampleSettings` from `useProviderState`. This means the renderer component doesn't need to use `useWatch` or `watch` to observe state changes manually.

## QA

- Open the showcase story.
- Inspect the showcase and see that its styles are set to `--font-family: Arial; --font-size: 16px; --line-height: 1.5;` by default, even before changing the config options. You can confirm this by inspecting the DOM (see screenshot below) or pressing the "Copy" button in the bottom right.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.

## Screenshots

Before **(notice `--font-size: undefinedpx`)**
<img width="399" alt="Screenshot 2025-04-02 at 16 35 14" src="https://github.com/user-attachments/assets/0a605894-4cb7-49c8-8d00-95cc1d0ccc97" />

After **(notice that the default typo specimen styles are applied properly)** 
<img width="399" alt="Screenshot 2025-04-02 at 16 35 28" src="https://github.com/user-attachments/assets/b5e10fa4-6012-422f-924b-6ba66ba98124" />

