### PR TITLE
feat(Demo site): Add example reset button

### DIFF
--- a/apps/react/demo/src/ui/Showcase/common/Example/common/Controls/Controls.tsx
+++ b/apps/react/demo/src/ui/Showcase/common/Example/common/Controls/Controls.tsx
@@ -42,13 +42,13 @@ const Controls = ({ id, className, style }: ControlsProps): ReactElement => {
         autoFit={true}
         Message={
           <>
-            {activeExample.fields.map(
+            <h4>Example settings</h4>
             <Button
               label={"Reset to defaults"}
               type={"button"}
               onClick={resetActiveExample}
             />
-                ...fieldProps
+            <hr />
             <div className="inputs">
               {activeExample.fields.map(
                 ({

--- a/apps/react/demo/src/ui/Showcase/common/Example/common/Controls/Controls.tsx
+++ b/apps/react/demo/src/ui/Showcase/common/Example/common/Controls/Controls.tsx
@@ -14,6 +14,7 @@ const Controls = ({ id, className, style }: ControlsProps): ReactElement => {
     activatePrevExample,
     activateNextExample,
     copyOutput,
+    resetActiveExample,
   } = useShowcaseContext();
 
   return (
@@ -40,24 +41,33 @@ const Controls = ({ id, className, style }: ControlsProps): ReactElement => {
         activateDelay={0}
         autoFit={true}
         Message={
-          <div className="inputs">
+          <>
             {activeExample.fields.map(
-              ({
-                name,
-                defaultValue,
-                transformer,
-                disabledOutputFormats,
+            <Button
+              label={"Reset to defaults"}
+              type={"button"}
+              onClick={resetActiveExample}
+            />
                 ...fieldProps
-              }) => (
-                <Field
-                  name={name}
-                  key={name}
-                  unregisterOnUnmount={false}
-                  {...fieldProps}
-                />
-              ),
-            )}
-          </div>
+            <div className="inputs">
+              {activeExample.fields.map(
+                ({
+                  name,
+                  defaultValue,
+                  transformer,
+                  disabledOutputFormats,
+                  ...fieldProps
+                }) => (
+                  <Field
+                    name={name}
+                    key={name}
+                    unregisterOnUnmount={false}
+                    {...fieldProps}
+                  />
+                ),
+              )}
+            </div>
+          </>
         }
       >
         <Button label="Configure" />

--- a/apps/react/demo/src/ui/Showcase/common/Example/common/Controls/Controls.tsx
+++ b/apps/react/demo/src/ui/Showcase/common/Example/common/Controls/Controls.tsx
@@ -74,7 +74,7 @@ const Controls = ({ id, className, style }: ControlsProps): ReactElement => {
       </TooltipArea>
       <Button
         type="button"
-        label="Copy"
+        label="Copy CSS"
         style={{ marginLeft: "auto" }}
         disabled={!output?.css}
         onClick={() => copyOutput("css")}

--- a/apps/react/demo/src/ui/Showcase/common/Example/common/Renderer/Renderer.tsx
+++ b/apps/react/demo/src/ui/Showcase/common/Example/common/Renderer/Renderer.tsx
@@ -13,7 +13,7 @@ const Renderer = ({ style, className }: RendererProps) => {
       style={style}
       className={[componentCssClassname, className].filter(Boolean).join(" ")}
     >
-      <h4>{activeExample.name}</h4>
+      <h3>{activeExample.name}</h3>
       <p>{activeExample.description}</p>
       {activeExample?.Component && (
         <root.div style={output.css} mode={"closed"}>

--- a/apps/react/demo/src/ui/Showcase/common/Example/hooks/useProviderState.ts
+++ b/apps/react/demo/src/ui/Showcase/common/Example/hooks/useProviderState.ts
@@ -81,6 +81,17 @@ const useProviderState = ({
     [formValues, activeExample],
   );
 
+  /** Resets the active example to its default state */
+  const resetActiveExample = useCallback(() => {
+    for (const field of activeExample.fields) {
+      if (!field[ORIGINAL_VAR_NAME_KEY]) continue;
+      setValue(
+        field.name,
+        defaultValues[activeExample.name][field[ORIGINAL_VAR_NAME_KEY]],
+      );
+    }
+  }, [activeExample, defaultValues, setValue]);
+
   useEffect(() => {
     // When the active example changes, set the form values to the new example's values
     for (const field of activeExample.fields) {
@@ -109,6 +120,7 @@ const useProviderState = ({
       activateNextExample,
       output,
       activeExampleFormValues,
+      resetActiveExample,
     }),
     [
       activeExampleIndex,
@@ -119,6 +131,7 @@ const useProviderState = ({
       activateNextExample,
       output,
       activeExampleFormValues,
+      resetActiveExample,
     ],
   );
 };

--- a/apps/react/demo/src/ui/Showcase/common/Example/types.ts
+++ b/apps/react/demo/src/ui/Showcase/common/Example/types.ts
@@ -17,6 +17,8 @@ export interface ContextOptions {
   allExamples: ShowcaseExample[];
   /** The currently active example's parameters */
   activeExample: ShowcaseExample;
+  /** Resets the active example to its default state */
+  resetActiveExample: () => void;
   /** The output values (e.g. CSS) for the currently active example */
   output: Output;
   /** Function to copy the output values of a format  */


### PR DESCRIPTION
## Done

- Adds a reset button to the example controls. Pressing the reset button resets the example to its default settings.
- Adds a heading at the top of the example controls tooltip, to better contextualize the reset button's purpose.
- Changes the heading level of the example renderer, so that the example renderer uses a higher heading level than the controls tooltip.

Fixes [WD-21283](https://warthogs.atlassian.net/browse/WD-21283)

## QA

- Open [demo](https://67e2cffc51800d09d0f838fd-tzkvuvramn.chromatic.com/iframe.html?globals=&args=&id=showcase--default&viewMode=story)
- Change example settings
- Press the reset button
- Verify that the settings have been reset to their defaults.

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.

## Screenshots

<img width="350" alt="Screenshot 2025-04-07 at 14 58 11" src="https://github.com/user-attachments/assets/9a16f5ef-e27c-4182-be6f-f16ce417ca61" />


[WD-21283]: https://warthogs.atlassian.net/browse/WD-21283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ