### PR TITLE
feat(Styles): Extract baseline grid css styles to a "debug" styles package

### DIFF
--- a/apps/react/boilerplate-vite/.storybook/preview.ts
+++ b/apps/react/boilerplate-vite/.storybook/preview.ts
@@ -2,6 +2,7 @@ import { withThemeByClassName } from "@storybook/addon-themes";
 import type { Preview, ReactRenderer } from "@storybook/react";
 
 import "index.css";
+import "@canonical/styles-debug/baseline-grid";
 
 const preview: Preview = {
   decorators: [

--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
     },
     "apps/react/boilerplate-vite": {
       "name": "@canonical/react-boilerplate-vite",
-      "version": "0.9.0-experimental.11",
+      "version": "0.9.0-experimental.13",
       "dependencies": {
         "@canonical/react-ssr": "^0.9.0-experimental.10",
         "@canonical/storybook-config": "^0.9.0-experimental.5",
@@ -39,7 +39,7 @@
     },
     "apps/react/demo": {
       "name": "@canonical/ds-demo-site",
-      "version": "0.9.0-experimental.11",
+      "version": "0.9.0-experimental.14",
       "dependencies": {
         "@canonical/react-ds-core": "^0.9.0-experimental.11",
         "@canonical/react-ds-core-form": "^0.9.0-experimental.11",
@@ -74,7 +74,7 @@
     },
     "configs/biome": {
       "name": "@canonical/biome-config",
-      "version": "0.9.0-experimental.2",
+      "version": "0.9.0-experimental.12",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
       },
@@ -84,7 +84,7 @@
     },
     "configs/storybook": {
       "name": "@canonical/storybook-config",
-      "version": "0.9.0-experimental.11",
+      "version": "0.9.0-experimental.12",
       "dependencies": {
         "@canonical/storybook-addon-baseline-grid": "^0.9.0-experimental.2",
         "@storybook/addon-essentials": "^8.4.7",
@@ -107,10 +107,10 @@
     },
     "configs/typescript-base": {
       "name": "@canonical/typescript-config-base",
-      "version": "0.9.0-experimental.2",
+      "version": "0.9.0-experimental.12",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@canonical/biome-config": "^0.9.0-experimental.2",
+        "@canonical/biome-config": "^0.9.0-experimental.12",
         "typescript": "^5.8.2",
       },
       "peerDependencies": {
@@ -119,13 +119,13 @@
     },
     "configs/typescript-react": {
       "name": "@canonical/typescript-config-react",
-      "version": "0.9.0-experimental.2",
+      "version": "0.9.0-experimental.12",
       "dependencies": {
-        "@canonical/typescript-config-base": "^0.9.0-experimental.2",
+        "@canonical/typescript-config-base": "^0.9.0-experimental.12",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@canonical/biome-config": "^0.9.0-experimental.2",
+        "@canonical/biome-config": "^0.9.0-experimental.12",
         "typescript": "^5.8.2",
       },
       "peerDependencies": {
@@ -134,7 +134,7 @@
     },
     "packages/generator-ds": {
       "name": "@canonical/generator-ds",
-      "version": "0.9.0-experimental.9",
+      "version": "0.9.0-experimental.12",
       "dependencies": {
         "@canonical/utils": "^0.9.0-experimental.9",
         "yeoman-generator": "^7.4.0",
@@ -152,7 +152,7 @@
     },
     "packages/react/ds-app-launchpad": {
       "name": "@canonical/react-ds-app-launchpad",
-      "version": "0.9.0-experimental.11",
+      "version": "0.9.0-experimental.15",
       "dependencies": {
         "@canonical/storybook-config": "^0.9.0-experimental.11",
         "@canonical/styles": "^0.9.0-experimental.9",
@@ -192,7 +192,7 @@
     },
     "packages/react/ds-core": {
       "name": "@canonical/react-ds-core",
-      "version": "0.9.0-experimental.11",
+      "version": "0.9.0-experimental.13",
       "dependencies": {
         "@canonical/storybook-config": "^0.9.0-experimental.11",
         "@canonical/styles": "^0.9.0-experimental.9",
@@ -225,7 +225,7 @@
     },
     "packages/react/ds-core-form": {
       "name": "@canonical/react-ds-core-form",
-      "version": "0.9.0-experimental.11",
+      "version": "0.9.0-experimental.13",
       "dependencies": {
         "@canonical/react-ds-core": "^0.9.0-experimental.11",
         "@canonical/storybook-config": "^0.9.0-experimental.11",
@@ -261,7 +261,7 @@
     },
     "packages/react/ssr": {
       "name": "@canonical/react-ssr",
-      "version": "0.9.0-experimental.10",
+      "version": "0.9.0-experimental.12",
       "bin": {
         "serve-express": "./dist/esm/server/serve-express.js",
       },
@@ -284,14 +284,15 @@
     },
     "packages/storybook-addon-baseline-grid": {
       "name": "@canonical/storybook-addon-baseline-grid",
-      "version": "0.9.0-experimental.2",
+      "version": "0.9.0-experimental.12",
       "dependencies": {
+        "@canonical/styles-debug": "^0.9.0-experimental.12",
         "@storybook/icons": "^1.2.10",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@canonical/biome-config": "^0.9.0-experimental.2",
-        "@canonical/typescript-config-react": "^0.9.0-experimental.2",
+        "@canonical/biome-config": "^0.9.0-experimental.12",
+        "@canonical/typescript-config-react": "^0.9.0-experimental.12",
         "@storybook/addon-essentials": "^8.4.7",
         "@storybook/addon-interactions": "^8.4.7",
         "@storybook/addon-links": "^8.4.7",
@@ -313,9 +314,17 @@
         "storybook": "^8.4.7",
       },
     },
+    "packages/styles/debug": {
+      "name": "@canonical/styles-debug",
+      "version": "0.9.0-experimental.12",
+      "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
+        "@canonical/biome-config": "^0.9.0-experimental.12",
+      },
+    },
     "packages/styles/elements": {
       "name": "@canonical/styles-elements",
-      "version": "0.9.0-experimental.2",
+      "version": "0.9.0-experimental.12",
       "dependencies": {
         "normalize.css": "^8.0.1",
       },
@@ -326,7 +335,7 @@
     },
     "packages/styles/main/canonical": {
       "name": "@canonical/styles",
-      "version": "0.9.0-experimental.9",
+      "version": "0.9.0-experimental.12",
       "dependencies": {
         "@canonical/styles-elements": "^0.9.0-experimental.2",
         "@canonical/styles-modes-canonical": "^0.9.0-experimental.2",
@@ -343,7 +352,7 @@
     },
     "packages/styles/modes/canonical": {
       "name": "@canonical/styles-modes-canonical",
-      "version": "0.9.0-experimental.2",
+      "version": "0.9.0-experimental.12",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@canonical/biome-config": "^0.9.0-experimental.2",
@@ -351,7 +360,7 @@
     },
     "packages/styles/modes/density": {
       "name": "@canonical/styles-modes-density",
-      "version": "0.9.0-experimental.2",
+      "version": "0.9.0-experimental.12",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@canonical/biome-config": "^0.9.0-experimental.2",
@@ -359,7 +368,7 @@
     },
     "packages/styles/modes/intents": {
       "name": "@canonical/styles-modes-intents",
-      "version": "0.9.0-experimental.2",
+      "version": "0.9.0-experimental.12",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@canonical/biome-config": "^0.9.0-experimental.2",
@@ -367,7 +376,7 @@
     },
     "packages/styles/modes/motion": {
       "name": "@canonical/styles-modes-motion",
-      "version": "0.9.0-experimental.2",
+      "version": "0.9.0-experimental.12",
       "dependencies": {
         "normalize.css": "^8.0.1",
       },
@@ -378,7 +387,7 @@
     },
     "packages/styles/primitives/canonical": {
       "name": "@canonical/styles-primitives-canonical",
-      "version": "0.9.0-experimental.9",
+      "version": "0.9.0-experimental.12",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@canonical/biome-config": "^0.9.0-experimental.2",
@@ -386,7 +395,7 @@
     },
     "packages/typography": {
       "name": "@canonical/typography",
-      "version": "0.9.0-experimental.2",
+      "version": "0.9.0-experimental.12",
       "bin": {
         "extractFontData": "./src/extractFontData.ts",
       },
@@ -404,7 +413,7 @@
     },
     "packages/utils": {
       "name": "@canonical/utils",
-      "version": "0.9.0-experimental.9",
+      "version": "0.9.0-experimental.12",
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@canonical/biome-config": "^0.9.0-experimental.2",
@@ -501,6 +510,8 @@
     "@canonical/storybook-config": ["@canonical/storybook-config@workspace:configs/storybook"],
 
     "@canonical/styles": ["@canonical/styles@workspace:packages/styles/main/canonical"],
+
+    "@canonical/styles-debug": ["@canonical/styles-debug@workspace:packages/styles/debug"],
 
     "@canonical/styles-elements": ["@canonical/styles-elements@workspace:packages/styles/elements"],
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "configs/*",
     "packages/*",
     "packages/react/*",
+    "packages/styles/debug",
     "packages/styles/primitives/*",
     "packages/styles/modes/*",
     "packages/styles/elements",

--- a/packages/react/ds-app-launchpad/.storybook/preview.ts
+++ b/packages/react/ds-app-launchpad/.storybook/preview.ts
@@ -2,6 +2,7 @@ import { withThemeByClassName } from "@storybook/addon-themes";
 import type { Preview, ReactRenderer } from "@storybook/react";
 
 import "index.css";
+import "@canonical/styles-debug/baseline-grid";
 
 const preview: Preview = {
   decorators: [

--- a/packages/react/ds-core/.storybook/preview.ts
+++ b/packages/react/ds-core/.storybook/preview.ts
@@ -2,6 +2,7 @@ import { withThemeByClassName } from "@storybook/addon-themes";
 import type { Preview, ReactRenderer } from "@storybook/react";
 
 import "index.css";
+import "@canonical/styles-debug/baseline-grid";
 
 const preview: Preview = {
   decorators: [

--- a/packages/storybook-addon-baseline-grid/.storybook/preview.ts
+++ b/packages/storybook-addon-baseline-grid/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type { Preview } from "@storybook/react";
 
 import "@canonical/styles";
+import "@canonical/styles-debug/baseline-grid";
 
 const preview: Preview = {
   parameters: {

--- a/packages/storybook-addon-baseline-grid/package.json
+++ b/packages/storybook-addon-baseline-grid/package.json
@@ -34,7 +34,8 @@
     "check:ts": "tsc --noEmit"
   },
   "dependencies": {
-    "@storybook/icons": "^1.2.10"
+    "@storybook/icons": "^1.2.10",
+    "@canonical/styles-debug": "^0.9.0-experimental.12"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/storybook-addon-baseline-grid/src/withBaselineGrid.ts
+++ b/packages/storybook-addon-baseline-grid/src/withBaselineGrid.ts
@@ -8,59 +8,17 @@ import { KEY } from "./constants.js";
 
 export const withBaselineGrid = (StoryFn: StoryFunction<Renderer>) => {
   const [globals] = useGlobals();
-  const myAddon = globals[KEY];
+  const addonGlobals = globals[KEY];
 
   const utilityClassName = "with-baseline-grid";
-  const utilityTagId = "baseline-grid-style";
-  const color = "rgba(255, 0, 0, 0.2)";
-  const defaultHeight = "0.5rem";
-
-  const styleElement = `
-  :root {
-    --addon-baseline-grid-color: var(--baseline-grid-color, ${color});
-    --addon-baseline-height: var(--baseline-height, ${defaultHeight});
-    --addon-baseline-shift: var(--baseline-shift, 0);
-  }
-  .${utilityClassName} {
-    position: relative;
-  
-    &::after {
-      background: linear-gradient(
-        to top,
-        var(--addon-baseline-grid-color),
-        var(--addon-baseline-grid-color) 1px,
-        transparent 1px,
-        transparent
-      );
-      background-size: 100% var(--addon-baseline-height);
-      background-position: 0 var(--addon-baseline-shift);
-      bottom: 0;
-      content: "";
-      display: block;
-      left: 0;
-      pointer-events: none;
-      position: absolute;
-      right: 0;
-      top: 0;
-      z-index: 200;
-    }
-  }
-  `;
 
   useEffect(() => {
-    const styleExists = global.document.getElementById(utilityTagId);
-    if (!styleExists) {
-      const style = global.document.createElement("style");
-      style.id = utilityTagId;
-      style.textContent = styleElement;
-      global.document.head.appendChild(style);
-    }
-    if (myAddon) {
+    if (addonGlobals) {
       global.document.body.classList.add(utilityClassName);
     } else {
       global.document.body.classList.remove(utilityClassName);
     }
-  }, [myAddon]);
+  }, [addonGlobals]);
 
   return StoryFn();
 };

--- a/packages/styles/debug/README.md
+++ b/packages/styles/debug/README.md
@@ -1,0 +1,51 @@
+## Canonical Debugging styles
+
+This package includes a set of canonical debugging styles that can be used to quickly identify and debug issues in your
+code.
+They are not included in the base styles packages, but can be used in conjunction with them.
+
+### Getting started
+
+1. Install the package: `npm install @canonical/styles-debug`
+2. Import the styles you need:
+
+```css
+/* To import all styles */
+@import url("@canonical/styles-debug");
+
+/* To import only certain styles */
+@import url("@canonical/styles-debug/baseline-grid");
+```
+
+### Debug utilities
+
+#### Baseline grid
+
+The baseline grid utility allows you to visualize the baseline grid in your application.
+To use it, add the `with-baseline-grid` class to any element.
+This will add a background color to the element and its children, allowing you to see the baseline grid in action.
+
+##### Customization
+
+This utility can be customized by setting the following CSS variables:
+
+| Variable                | Description                           | Default Value          |
+|-------------------------|---------------------------------------|------------------------|
+| `--baseline-grid-color` | The color of the baseline grid lines  | `rgba(255, 0, 0, 0.2)` |
+| `--baseline-height`     | The height of the baseline grid       | `0.5rem`               |
+| `--baseline-shift`      | The offset shift of the baseline grid | `0`                    |
+
+##### Example
+
+```html
+<link rel="stylesheet" href="https://unpkg.com/@canonical/styles-debug/src/baseline-grid.css">
+<style>
+    :root {
+        --baseline-grid-color: teal;
+    }
+</style>
+<div class="with-baseline-grid">
+    <p>Some text</p>
+    <p>Some more text</p>
+</div>
+```

--- a/packages/styles/debug/biome.json
+++ b/packages/styles/debug/biome.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "extends": ["@canonical/biome-config"],
+  "files": {
+    "include": ["src", "*.json"]
+  }
+}

--- a/packages/styles/debug/package.json
+++ b/packages/styles/debug/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@canonical/styles-debug",
+  "description": "Canonical's debugging styles. These are not included with the rest of the styles, but can be used for debugging purposes.",
+  "version": "0.9.0-experimental.12",
+  "main": "src/index.css",
+  "files": ["src"],
+  "author": {
+    "email": "webteam@canonical.com",
+    "name": "Canonical Webteam"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/canonical/ds25"
+  },
+  "exports": {
+    ".": {
+      "import": "./src/index.css"
+    },
+    "./baseline-grid": {
+      "import": "./src/baseline-grid.css"
+    }
+  },
+  "license": "LGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/canonical/ds25/issues"
+  },
+  "homepage": "https://github.com/canonical/ds25#readme",
+  "scripts": {
+    "check": "bun run check:biome",
+    "check:fix": "bun run check:biome:fix",
+    "check:biome": "biome check",
+    "check:biome:fix": "biome check --write"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@canonical/biome-config": "^0.9.0-experimental.12"
+  }
+}

--- a/packages/styles/debug/src/baseline-grid.css
+++ b/packages/styles/debug/src/baseline-grid.css
@@ -1,0 +1,28 @@
+.with-baseline-grid {
+  --addon-baseline-grid-color: var(--baseline-grid-color, rgba(255, 0, 0, 0.2));
+  --addon-baseline-height: var(--baseline-height, 0.5rem);
+  --addon-baseline-shift: var(--baseline-shift, 0);
+
+  position: relative;
+
+  &::after {
+    background: linear-gradient(
+      to top,
+      var(--addon-baseline-grid-color),
+      var(--addon-baseline-grid-color) 1px,
+      transparent 1px,
+      transparent
+    );
+    background-size: 100% var(--addon-baseline-height);
+    background-position: 0 var(--addon-baseline-shift);
+    bottom: 0;
+    content: "";
+    display: block;
+    left: 0;
+    pointer-events: none;
+    position: absolute;
+    right: 0;
+    top: 0;
+    z-index: 200;
+  }
+}

--- a/packages/styles/debug/src/index.css
+++ b/packages/styles/debug/src/index.css
@@ -1,0 +1,1 @@
+@import url("./baseline-grid.css");


### PR DESCRIPTION
## Done

The [baseline grid storybook addon](https://www.npmjs.com/package/@canonical/storybook-addon-baseline-grid) tightly couples the baseline styling with the storybook plugin ecosystem. To allow for non-storybook architectures (like the demo site) to use the baseline grid styling, I have extracted the baseline styling to its own package, currently called `@canonical/styles-debug`.  This allows the storybook plugin and other non-storybook consumers to share the same functionality. 

I'm not sure if this is the best naming or place in the file structure to place this package, but happy to discuss & modify as that is pretty cheap to do.

## QA
1.  Open all of the published storybooks. 
2. Open any story, enable the baseline grid addon, and verify that the baseline is still rendered as expected. 

### PR readiness check

- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.