### PR TITLE
fix(React Core): Fix Tooltip bridge arrow being clipped when the tooltip message is tall & has wrapping text

### DIFF
--- a/packages/react/ds-core/src/ui/Tooltip/Tooltip.tests.tsx
+++ b/packages/react/ds-core/src/ui/Tooltip/Tooltip.tests.tsx
@@ -15,7 +15,7 @@ describe("Tooltip component", () => {
 
   it("applies additional className prop", async () => {
     render(
-      <Tooltip className="test-class" isOpen={true}>
+      <Tooltip positionElementClassName="test-class" isOpen={true}>
         Tooltip Content
       </Tooltip>,
     );
@@ -37,7 +37,7 @@ describe("Tooltip component", () => {
 
   it("applies id prop", async () => {
     render(
-      <Tooltip id="test-id" isOpen={true}>
+      <Tooltip positionElementId="test-id" isOpen={true}>
         Tooltip Content
       </Tooltip>,
     );
@@ -103,7 +103,7 @@ describe("Tooltip component", () => {
 
   it("correctly handles multiple class names", async () => {
     render(
-      <Tooltip className="class1 class2" isOpen={true}>
+      <Tooltip positionElementClassName="class1 class2" isOpen={true}>
         Tooltip Content
       </Tooltip>,
     );

--- a/packages/react/ds-core/src/ui/Tooltip/Tooltip.tsx
+++ b/packages/react/ds-core/src/ui/Tooltip/Tooltip.tsx
@@ -12,9 +12,11 @@ const componentCssClassName = "ds tooltip";
  * - The [withTooltip](?path=/docs/tooltip-withtooltip--docs) HOC
  */
 const Tooltip = ({
-  id,
+  positionElementId,
+  positionElementClassName,
+  messageElementId,
+  messageElementClassName,
   children,
-  className,
   style,
   ref,
   isOpen = false,
@@ -24,20 +26,28 @@ const Tooltip = ({
 }: TooltipProps): React.ReactElement => {
   return (
     <div
-      className={[componentCssClassName, className].filter(Boolean).join(" ")}
+      id={positionElementId}
+      className={[componentCssClassName, positionElementClassName]
+        .filter(Boolean)
+        .join(" ")}
       ref={ref}
-      id={id}
       aria-hidden={!isOpen}
       onPointerEnter={onPointerEnter}
       onFocus={onFocus}
       role="tooltip"
       style={{
         ...style,
-        visibility: isOpen ? "visible" : "hidden",
         zIndex,
       }}
     >
-      {children}
+      <div
+        id={messageElementId}
+        className={[messageElementClassName, "message"]
+          .filter(Boolean)
+          .join(" ")}
+      >
+        {children}
+      </div>
     </div>
   );
 };

--- a/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
+++ b/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
@@ -63,6 +63,23 @@ export const Bottom: Story = {
   },
 };
 
+export const Wrapping: Story = {
+  args: {
+    Message: (
+      <span>
+        orem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum.
+      </span>
+    ),
+    children: <Button label="Wrapping" />,
+  },
+};
+
 export const Changeable: StoryFn = () => {
   const options: WindowFitmentDirection[] = ["top", "right", "bottom", "left"];
 

--- a/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.tsx
+++ b/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.tsx
@@ -22,8 +22,11 @@ const TooltipArea = ({
   targetElementId,
   targetElementClassName,
   targetElementStyle,
-  messageElementClassName,
   messageElementStyle,
+  messageElementId,
+  messageElementClassName,
+  positionElementId,
+  positionElementClassName,
   parentElement,
   autoFit,
   ...props
@@ -43,10 +46,11 @@ const TooltipArea = ({
 
   const TooltipMessageElement = (
     <Tooltip
-      id={popupId}
-      className={[
+      positionElementId={popupId}
+      messageElementId={messageElementId}
+      messageElementClassName={messageElementClassName}
+      positionElementClassName={[
         bestPosition?.positionName,
-        messageElementClassName,
         autoFit && "autofit",
       ]
         .filter(Boolean)

--- a/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/types.ts
+++ b/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/types.ts
@@ -1,7 +1,8 @@
 import type { CSSProperties, ReactNode } from "react";
 import type { UsePopupProps } from "../../../hooks/index.js";
+import type { TooltipProps } from "../../types.js";
 
-export interface TooltipAreaProps extends UsePopupProps {
+export interface TooltipAreaProps extends UsePopupProps, TooltipProps {
   /**
    * The target element to which the tooltip should be attached.
    * This can be any valid React element.
@@ -21,8 +22,6 @@ export interface TooltipAreaProps extends UsePopupProps {
   targetElementClassName?: string;
   /** Style object applied to the target element */
   targetElementStyle?: CSSProperties;
-  /** Class name applied to the tooltip/message element */
-  messageElementClassName?: string;
   /** Styles applied to the tooltip/message element */
   messageElementStyle?: CSSProperties;
   /**

--- a/packages/react/ds-core/src/ui/Tooltip/styles.css
+++ b/packages/react/ds-core/src/ui/Tooltip/styles.css
@@ -31,36 +31,38 @@
   --tooltip-border-arrow-hidden: var(--tooltip-spacing-arrow-size) solid
     transparent;
 
-  color: var(
-    --intent-color-text,
-    var(--tooltip-color-text, var(--color-text-default))
-  );
-  background-color: var(
-    --intent-color,
-    var(--tooltip-color-background, var(--color-background-default))
-  );
-  border-color: var(
-    --intent-color-border,
-    var(--tooltip-color-border, transparent)
-  );
-  border-style: solid;
-  border-radius: var(--tooltip-border-radius);
-  border-width: var(--tooltip-border-width, 1px);
-  font-size: var(--tooltip-font-size, var(--font-size-small));
-  font-weight: var(--tooltip-font-weight, var(--font-weight-default));
-  line-height: var(--tooltip-line-height, var(--line-height-small));
-  margin-block-end: var(--tooltip-margin-bottom, 0);
-  margin-inline-end: var(--tooltip-margin-left, 0);
-  padding-block: var(--tooltip-padding-vertical, 5px);
-  padding-inline: var(--tooltip-padding-horizontal, 10px);
-  white-space: pre;
-  text-align: left;
-  text-decoration: initial;
-  pointer-events: auto;
   display: inline-block;
-  transition: opacity 0.1s ease-in-out;
   position: fixed;
-  overflow: auto;
+  transition: opacity 0.1s ease-in-out;
+
+  & .message {
+    color: var(
+      --intent-color-text,
+      var(--tooltip-color-text, var(--color-text-default))
+    );
+    background-color: var(
+      --intent-color,
+      var(--tooltip-color-background, var(--color-background-default))
+    );
+    border-color: var(
+      --intent-color-border,
+      var(--tooltip-color-border, transparent)
+    );
+    border-style: solid;
+    border-radius: var(--tooltip-border-radius);
+    border-width: var(--tooltip-border-width, 1px);
+    font-size: var(--tooltip-font-size, var(--font-size-small));
+    font-weight: var(--tooltip-font-weight, var(--font-weight-default));
+    line-height: var(--tooltip-line-height, var(--line-height-small));
+    margin-block-end: var(--tooltip-margin-bottom, 0);
+    margin-inline-end: var(--tooltip-margin-left, 0);
+    padding-block: var(--tooltip-padding-vertical, 5px);
+    padding-inline: var(--tooltip-padding-horizontal, 10px);
+    text-align: left;
+    text-decoration: initial;
+    pointer-events: auto;
+    overflow: auto;
+  }
 
   &[aria-hidden="true"] {
     opacity: 0;

--- a/packages/react/ds-core/src/ui/Tooltip/types.ts
+++ b/packages/react/ds-core/src/ui/Tooltip/types.ts
@@ -5,13 +5,16 @@ import type {
   ReactNode,
   RefObject,
 } from "react";
-import type { BestPosition } from "../hooks/index.js";
 
 export interface TooltipProps {
-  /* A unique identifier for the TooltipMessage */
-  id?: string;
-  /* Additional CSS classes */
-  className?: string;
+  /* ID to apply to the positioning element */
+  positionElementId?: string;
+  /* Class name to apply to the positioning element */
+  positionElementClassName?: string;
+  /* ID to apply to the message element */
+  messageElementId?: string;
+  /* Class name to apply to the message element */
+  messageElementClassName?: string;
   /* Child elements */
   children: ReactNode;
   /* Inline styles */
@@ -22,7 +25,8 @@ export interface TooltipProps {
   ref?: RefObject<HTMLDivElement | null>;
   /** The z-index of the tooltip */
   zIndex?: number;
-
+  /* Event handler for pointer enter */
   onPointerEnter?: PointerEventHandler;
+  /* Event handler for focus */
   onFocus?: FocusEventHandler;
 }


### PR DESCRIPTION
## Done

The tooltip component currently renders the tooltip message element with fixed positioning styles AND the typical tooltip message styles (background, overflow behavior, etc), all within one element. 

The bridge arrow is a pseudoelement of this element, which makes it possible for the arrow to be rendered within the tooltip body itself, especially in cases where there is a lot of text in the tooltip body. This causes unnecessary scroll/overflow and causes the arrow to not be rendered in the correct place. 

This PR fixes this by moving the actual tooltip message element (the styled part of the tooltip) into a `.ds.tooltip .message` element, while the `.ds.tooltip` element is purely used for positioning. This should make it impossible for the bridge arrow to be clipped. 

## QA

- Open all tooltip stories (especially the new Wrapping story)
- Ensure that the tooltip renders in the expected posiiton (especially the bridge arrow). 

### PR readiness check

- [ ] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with a build step: `build`.

## Screenshots

![image](https://github.com/user-attachments/assets/e24810dc-7c8d-42ba-a64e-a3ad53a1e5d1)
