### PR TITLE
fix(GitDiffViewer): correct line highlighting logic in diff viewer

### DIFF
--- a/packages/react/ds-app-launchpad/src/ui/GitDiffViewer/utils/highlightDiffHunkLines.ts
+++ b/packages/react/ds-app-launchpad/src/ui/GitDiffViewer/utils/highlightDiffHunkLines.ts
@@ -22,16 +22,25 @@ function highlightDiffHunkLines(hunkLines: Hunk["lines"]): string[] {
     hunkContentDeletedVersion,
   ).split("\n");
 
-  const highlightedLines: string[] = hunkLines.map((line, index) => {
+  const highlightedLines: string[] = [];
+  let addedOffset = 0;
+  let removedOffset = 0;
+  for (let i = 0; i < hunkLines.length; i++) {
+    const line = hunkLines[i];
     switch (line.type) {
       case "context":
-        return highlightedHunkAddedVersion[index];
+        highlightedLines.push(highlightedHunkDeletedVersion[i - addedOffset]);
+        break;
       case "remove":
-        return highlightedHunkDeletedVersion[index];
+        highlightedLines.push(highlightedHunkDeletedVersion[i - addedOffset]);
+        removedOffset++;
+        break;
       case "add":
-        return highlightedHunkAddedVersion[index];
+        highlightedLines.push(highlightedHunkAddedVersion[i - removedOffset]);
+        addedOffset++;
+        break;
     }
-  });
+  }
 
   return highlightedLines;
 }


### PR DESCRIPTION
## Done

Use correct line highlighting logic in diff viewer.

### PR readiness check


- [x] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [x] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [x] All packages define the required scripts in `package.json`:
  - [x] All packages: `check`, `check:fix`, and `test`.
  - [x] Packages with a build step: `build`.
