### PR TITLE
feat(React Core): Button uses `children` instead of `label` for contents

### DIFF
--- a/apps/react/boilerplate-vite/src/Application.tsx
+++ b/apps/react/boilerplate-vite/src/Application.tsx
@@ -40,10 +40,9 @@ function App() {
           preferredDirections={["right", "bottom"]}
           Message={`Increment count to ${count + 1}`}
         >
-          <Button
-            label={`Count: ${count}`}
-            onClick={() => setCount((count) => count + 1)}
-          />
+          <Button onClick={() => setCount((count) => count + 1)}>
+            Count: {count}
+          </Button>
         </TooltipArea>
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR

--- a/apps/react/boilerplate-vite/src/LazyComponent.tsx
+++ b/apps/react/boilerplate-vite/src/LazyComponent.tsx
@@ -2,11 +2,9 @@ import { Button } from "@canonical/react-ds-core";
 
 function LazyComponent() {
   return (
-    <Button
-      appearance={"positive"}
-      label={"Click me"}
-      onClick={() => alert("clicked!")}
-    />
+    <Button appearance={"positive"} onClick={() => alert("clicked!")}>
+      Click me
+    </Button>
   );
 }
 

--- a/apps/react/demo/src/data/examples/ButtonExample/ButtonExample.tsx
+++ b/apps/react/demo/src/data/examples/ButtonExample/ButtonExample.tsx
@@ -8,9 +8,10 @@ const ButtonExample: ShowcaseComponent = ({ numButtons }) => {
         type="button"
         // biome-ignore lint/suspicious/noArrayIndexKey: demonstrative purposes only
         key={i}
-        label="Test button"
         onClick={() => alert("clicked!")}
-      />
+      >
+        Test button
+      </Button>
     ));
   }, [numButtons]);
 

--- a/apps/react/demo/src/ui/Showcase/common/Example/common/Controls/Controls.tsx
+++ b/apps/react/demo/src/ui/Showcase/common/Example/common/Controls/Controls.tsx
@@ -30,8 +30,12 @@ const Controls = ({ id, className, style }: ControlsProps): ReactElement => {
     >
       <div>
         {/*TODO use icon buttons when icon is implemented*/}
-        <Button label={"Prev"} type="button" onClick={activatePrevExample} />
-        <Button label="Next" type="button" onClick={activateNextExample} />
+        <Button type="button" onClick={activatePrevExample}>
+          Prev
+        </Button>
+        <Button type="button" onClick={activateNextExample}>
+          Next
+        </Button>
       </div>
       <TooltipArea
         // TODO use new form components when ready
@@ -43,11 +47,9 @@ const Controls = ({ id, className, style }: ControlsProps): ReactElement => {
         Message={
           <>
             <h4>Example settings</h4>
-            <Button
-              label={"Reset to defaults"}
-              type={"button"}
-              onClick={resetActiveExample}
-            />
+            <Button type={"button"} onClick={resetActiveExample}>
+              Reset to defaults
+            </Button>
             <hr />
             <div className="inputs">
               {activeExample.fields.map(
@@ -70,15 +72,16 @@ const Controls = ({ id, className, style }: ControlsProps): ReactElement => {
           </>
         }
       >
-        <Button label="Configure" />
+        <Button>Configure</Button>
       </TooltipArea>
       <Button
         type="button"
-        label="Copy CSS"
         style={{ marginLeft: "auto" }}
         disabled={!output?.css}
         onClick={() => copyOutput("css")}
-      />
+      >
+        Copy CSS
+      </Button>
     </div>
   );
 };

--- a/packages/react/ds-core-form/src/ui/Field/inputs/Combobox/common/ResetButton/ResetButton.tsx
+++ b/packages/react/ds-core-form/src/ui/Field/inputs/Combobox/common/ResetButton/ResetButton.tsx
@@ -20,14 +20,15 @@ const ResetButton = ({
 }: ResetButtonProps): React.ReactElement => {
   return (
     <Button
-      label="x" //TODO replace with semantic children
       id={id}
       style={style}
       className={[componentCssClassName, className].filter(Boolean).join(" ")}
       aria-label={messages.reset()}
       type="button"
       onClick={onClick}
-    />
+    >
+      x
+    </Button>
   );
 };
 

--- a/packages/react/ds-core/src/ui/Button/Button.stories.tsx
+++ b/packages/react/ds-core/src/ui/Button/Button.stories.tsx
@@ -27,7 +27,7 @@ type Story = StoryObj<typeof meta>;
  */
 export const Default: Story = {
   args: {
-    label: "Contact us",
+    children: "Contact us",
   },
 };
 
@@ -36,7 +36,7 @@ export const Default: Story = {
  */
 export const Positive: Story = {
   args: {
-    label: "Confirm",
+    children: "Confirm",
     appearance: "positive",
   },
 };
@@ -46,7 +46,7 @@ export const Positive: Story = {
  */
 export const Negative: Story = {
   args: {
-    label: "Delete",
+    children: "Delete",
     appearance: "negative",
   },
 };
@@ -56,7 +56,7 @@ export const Negative: Story = {
  */
 export const Custom: Story = {
   args: {
-    label: "Customize",
+    children: "Customize",
     className: "custom-class",
     style: {
       "--button-color-background": "lightblue",
@@ -85,13 +85,13 @@ export const IntentsInheritance: Story = {
         <p>
           I'm a wrapper with <code>positive</code> intent class name.
         </p>
-        <Button label="This is a neutral button" appearance="neutral" />
-        <Button label="This is a negative button" appearance="negative" />
-        <Button label="This button inherits the intent from parent" />
+        <Button appearance="neutral">This is a neutral button</Button>
+        <Button appearance="negative">This is a negative button</Button>
+        <Button>This button inherits the intent from parent</Button>
       </div>
     ),
   ],
   args: {
-    label: "Broken",
+    children: "Broken",
   },
 };

--- a/packages/react/ds-core/src/ui/Button/Button.stories.tsx
+++ b/packages/react/ds-core/src/ui/Button/Button.stories.tsx
@@ -28,6 +28,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     children: "Contact us",
+    disabled: true,
   },
 };
 
@@ -56,7 +57,8 @@ export const Negative: Story = {
  */
 export const Custom: Story = {
   args: {
-    children: "Customize",
+    children: <span>Customize</span>,
+    "aria-label": "Customize",
     className: "custom-class",
     style: {
       "--button-color-background": "lightblue",

--- a/packages/react/ds-core/src/ui/Button/Button.tests.tsx
+++ b/packages/react/ds-core/src/ui/Button/Button.tests.tsx
@@ -4,12 +4,12 @@ import Component from "./Button.js";
 
 describe("Button component", () => {
   it("renders", () => {
-    render(<Component label={"Hello world!"} />);
+    render(<Component>Hello world!</Component>);
     expect(screen.getByText("Hello world!")).toBeInTheDocument();
   });
 
   it("applies className", () => {
-    render(<Component label={"Hello world!"} className="test-class" />);
+    render(<Component className="test-class">Hello world!</Component>);
     expect(screen.getByText("Hello world!")).toHaveClass("test-class");
   });
 });

--- a/packages/react/ds-core/src/ui/Button/Button.tsx
+++ b/packages/react/ds-core/src/ui/Button/Button.tsx
@@ -7,8 +7,6 @@ const Button = ({
   className,
   children,
   style,
-  // This prop is deprecated but kept for backwards compatibility.
-  label,
   appearance,
   ...props
 }: Props): React.ReactElement => {
@@ -21,10 +19,10 @@ const Button = ({
       style={style}
       // Apply custom aria label if provided, otherwise use children text.
       // If the child is a JSX element (and not just a string), a custom aria-label should be used, otherwise the aria-label will be [object Object].
-      aria-label={label || props["aria-label"] || children?.toString() || ""}
+      aria-label={props["aria-label"] || children?.toString()}
       {...props}
     >
-      {label || children}
+      {props["aria-label"] || children}
     </button>
   );
 };

--- a/packages/react/ds-core/src/ui/Button/Button.tsx
+++ b/packages/react/ds-core/src/ui/Button/Button.tsx
@@ -19,7 +19,8 @@ const Button = ({
       style={style}
       // Apply custom aria label if provided, otherwise use children text.
       // If the child is a JSX element (and not just a string), a custom aria-label should be used, otherwise the aria-label will be [object Object].
-      aria-label={props["aria-label"] || children}
+      // toString() needed to avoid type error for non-string children
+      aria-label={props["aria-label"] || children?.toString()}
       {...props}
     >
       {children}

--- a/packages/react/ds-core/src/ui/Button/Button.tsx
+++ b/packages/react/ds-core/src/ui/Button/Button.tsx
@@ -10,7 +10,6 @@ const Button = ({
   // This prop is deprecated but kept for backwards compatibility.
   label,
   appearance,
-  disabled,
   ...props
 }: Props): React.ReactElement => {
   return (
@@ -20,8 +19,6 @@ const Button = ({
         .filter(Boolean)
         .join(" ")}
       style={style}
-      disabled={disabled}
-      aria-disabled={disabled}
       // Apply custom aria label if provided, otherwise use children text.
       // If the child is a JSX element (and not just a string), a custom aria-label should be used, otherwise the aria-label will be [object Object].
       aria-label={label || props["aria-label"] || children?.toString() || ""}

--- a/packages/react/ds-core/src/ui/Button/Button.tsx
+++ b/packages/react/ds-core/src/ui/Button/Button.tsx
@@ -19,10 +19,10 @@ const Button = ({
       style={style}
       // Apply custom aria label if provided, otherwise use children text.
       // If the child is a JSX element (and not just a string), a custom aria-label should be used, otherwise the aria-label will be [object Object].
-      aria-label={props["aria-label"] || children?.toString()}
+      aria-label={props["aria-label"] || children}
       {...props}
     >
-      {props["aria-label"] || children}
+      {children}
     </button>
   );
 };

--- a/packages/react/ds-core/src/ui/Button/Button.tsx
+++ b/packages/react/ds-core/src/ui/Button/Button.tsx
@@ -5,8 +5,12 @@ import "./styles.css";
 const Button = ({
   id,
   className,
-  appearance,
+  children,
+  style,
+  // This prop is deprecated but kept for backwards compatibility.
   label,
+  appearance,
+  disabled,
   ...props
 }: Props): React.ReactElement => {
   return (
@@ -15,10 +19,15 @@ const Button = ({
       className={["ds", "button", appearance, className]
         .filter(Boolean)
         .join(" ")}
+      style={style}
+      disabled={disabled}
+      aria-disabled={disabled}
+      // Apply custom aria label if provided, otherwise use children text.
+      // If the child is a JSX element (and not just a string), a custom aria-label should be used, otherwise the aria-label will be [object Object].
+      aria-label={label || props["aria-label"] || children?.toString() || ""}
       {...props}
-      aria-label={label}
     >
-      {label}
+      {label || children}
     </button>
   );
 };

--- a/packages/react/ds-core/src/ui/Button/types.ts
+++ b/packages/react/ds-core/src/ui/Button/types.ts
@@ -23,13 +23,9 @@ export interface BaseProps {
    * `aria-label` prop to ensure that the button label is applied properly. Otherwise, the label will be set to [object Object].
    * TODO remove optional when we remove the `label` prop.
    * */
-  children?: ReactNode;
-  // for backwards compatibility, when we used label instead of children
-  label?: string;
+  children: ReactNode;
   /** The visual style of the button */
   appearance?: "neutral" | "base" | "positive" | "negative" | "link";
-  /** Optional click handler */
-  onClick?: () => void;
 }
 
 type Props = BaseProps & ButtonHTMLAttributes<HTMLButtonElement>;

--- a/packages/react/ds-core/src/ui/Button/types.ts
+++ b/packages/react/ds-core/src/ui/Button/types.ts
@@ -21,7 +21,6 @@ export interface BaseProps {
    * This will also be used for the `aria-label`.
    * If this contains anything other than a string literal (such as a <p> element), you should specify an
    * `aria-label` prop to ensure that the button label is applied properly. Otherwise, the label will be set to [object Object].
-   * TODO remove optional when we remove the `label` prop.
    * */
   children: ReactNode;
   /** The visual style of the button */

--- a/packages/react/ds-core/src/ui/Button/types.ts
+++ b/packages/react/ds-core/src/ui/Button/types.ts
@@ -1,5 +1,3 @@
-import type React from "react";
-
 // TODO: this is how appearance could work as enum
 //
 // export enum ButtonAppearance {
@@ -11,19 +9,29 @@ import type React from "react";
 // }
 //
 
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
 export interface BaseProps {
   /* A unique identifier for the button */
   id?: string;
   /** Additional CSS classes */
   className?: string;
+  /**
+   * Button contents.
+   * This will also be used for the `aria-label`.
+   * If this contains anything other than a string literal (such as a <p> element), you should specify an
+   * `aria-label` prop to ensure that the button label is applied properly. Otherwise, the label will be set to [object Object].
+   * TODO remove optional when we remove the `label` prop.
+   * */
+  children?: ReactNode;
+  // for backwards compatibility, when we used label instead of children
+  label?: string;
   /** The visual style of the button */
   appearance?: "neutral" | "base" | "positive" | "negative" | "link";
-  /** Button contents */
-  label: string;
   /** Optional click handler */
   onClick?: () => void;
 }
 
-type Props = BaseProps & React.ButtonHTMLAttributes<HTMLButtonElement>;
+type Props = BaseProps & ButtonHTMLAttributes<HTMLButtonElement>;
 
 export default Props;

--- a/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
+++ b/packages/react/ds-core/src/ui/Tooltip/common/TooltipArea/TooltipArea.stories.tsx
@@ -27,7 +27,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     Message: "Hello world",
-    children: <Button label="Default" />,
+    children: <Button>Default</Button>,
   },
 };
 
@@ -35,7 +35,7 @@ export const Top: Story = {
   args: {
     Message: "Hello world",
     preferredDirections: ["top"],
-    children: <Button label="Top" />,
+    children: <Button>Top</Button>,
   },
 };
 
@@ -43,7 +43,7 @@ export const Left: Story = {
   args: {
     Message: "Hello world",
     preferredDirections: ["left"],
-    children: <Button label="Left" />,
+    children: <Button>Left</Button>,
   },
 };
 
@@ -51,7 +51,7 @@ export const Right: Story = {
   args: {
     Message: "Hello world",
     preferredDirections: ["right", "top"],
-    children: <Button label="Right" />,
+    children: <Button>Right</Button>,
   },
 };
 
@@ -59,7 +59,7 @@ export const Bottom: Story = {
   args: {
     Message: "Hello world",
     preferredDirections: ["bottom", "top", "left", "right"],
-    children: <Button label="Bottom" />,
+    children: <Button>Bottom</Button>,
   },
 };
 
@@ -84,10 +84,9 @@ export const Changeable: StoryFn = () => {
       preferredDirections={[preferredDirection]}
       onBestPositionChange={(p) => setBestPosition(p)}
     >
-      <Button
-        label="Click to change direction"
-        onClick={() => setChangeCount((prev) => prev + 1)}
-      />
+      <Button onClick={() => setChangeCount((prev) => prev + 1)}>
+        Click to change direction
+      </Button>
     </Component>
   );
 };
@@ -114,7 +113,7 @@ export const AutoFit: StoryFn = () => {
       autoFit={true}
       style={{ position: "absolute", bottom: 0, left: 0 }}
     >
-      <Button label={"Autofit"} />
+      <Button>Autofit</Button>
     </Component>
   );
 };

--- a/packages/react/ds-core/src/ui/Tooltip/withTooltip.stories.tsx
+++ b/packages/react/ds-core/src/ui/Tooltip/withTooltip.stories.tsx
@@ -22,7 +22,7 @@ type Story = StoryObj<TooltipType>;
 export const Default: StoryFn = () => {
   const TooltippedButton = withTooltip(Button, <span>Tooltip content</span>);
 
-  return <TooltippedButton label="Hover me" />;
+  return <TooltippedButton>Hover me</TooltippedButton>;
 };
 
 Default.storyName = "Default";


### PR DESCRIPTION
## Done

1. `Button` now uses the `children` prop instead of the `label` prop to pass in contents.
2. The `label` prop has been kept to avoid making a breaking change to anyone currently using it with `label`. Not sure if I need to do this, as we are in an experimental stage.

## QA

1. Open Button stories
2. See that the aria labels reflect the button contents
3. Open the custom button story. See that its contents are a nested HTML element, and the aria label on the button is correct.
4. Use Chromatic otherwise

### PR readiness check

- [ ] PR should have one of the following labels:
  - `Feature 🎁`, `Breaking Change 💣`, `Bug 🐛`, `Documentation 📝`, `Maintenance 🔨`.
- [ ] PR title follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format. 
- [ ] All packages define the required scripts in `package.json`:
  - [ ] All packages: `check`, `check:fix`, and `test`.
  - [ ] Packages with a build step: `build`.
